### PR TITLE
fix: enable jsx in js files

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,10 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  esbuild: {
+    loader: 'tsx',
+    include: /src\/.*\.[tj]sx?$/
+  },
   server: {
     port: 3009
   },


### PR DESCRIPTION
## Summary
- configure Vite's esbuild to treat JS files as TSX so JSX compiles

## Testing
- `CI=1 timeout 5 yarn dev`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_688e90bf994c8324a89aa266c02053b2