### PR TITLE
refactor: use sass modules

### DIFF
--- a/src/components/algver-select/style.module.scss
+++ b/src/components/algver-select/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles/select";
+@use "../../styles/select" as *;
 
 .algver-select {
   width: 15rem;

--- a/src/components/analyze-forms/patterns-input-form/style.module.scss
+++ b/src/components/analyze-forms/patterns-input-form/style.module.scss
@@ -1,6 +1,6 @@
-@import "../../../styles";
-@import "../../../styles/tabs";
-@import "../../../styles/dropdown";
+@use "../../../styles" as *;
+@use "../../../styles/tabs" as *;
+@use "../../../styles/dropdown" as *;
 
 .patterns-input-container {
   // @include grid($flex-wrap: wrap, $gutter: 18px);

--- a/src/components/analyze-forms/style.module.scss
+++ b/src/components/analyze-forms/style.module.scss
@@ -1,7 +1,7 @@
-@import "../../styles";
-@import "../../styles/tabs";
-@import "../../styles/dropdown";
-@import "../../styles/functions";
+@use "../../styles" as *;
+@use "../../styles/tabs" as *;
+@use "../../styles/dropdown" as *;
+@use "../../styles/functions" as *;
 
 
 .analyze-form-tabs {

--- a/src/components/button/style.module.scss
+++ b/src/components/button/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 .btn {
   border: 1px solid transparent;

--- a/src/components/checkbox-input/style.module.scss
+++ b/src/components/checkbox-input/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 $chkbox-size: 1.28em;
 $chkbox-border-width: 1px;

--- a/src/components/dual-range-input/style.module.scss
+++ b/src/components/dual-range-input/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 .dual-number-range {
   display: grid;

--- a/src/components/file-input/style.module.scss
+++ b/src/components/file-input/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 span.file-input {
   display: inline-flex;

--- a/src/components/genome-map/style.module.scss
+++ b/src/components/genome-map/style.module.scss
@@ -1,5 +1,5 @@
-@import "../../styles/default-colors";
-@import "../../styles/functions";
+@use "../../styles/default-colors" as *;
+@use "../../styles/functions" as *;
 
 .map-container {
   position: relative;

--- a/src/components/heading-tags/style.module.scss
+++ b/src/components/heading-tags/style.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/colors';
+@use '../../styles/colors' as *;
 
 $anchor-width: 1.5rem;
 

--- a/src/components/intro/style.module.scss
+++ b/src/components/intro/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 .intro {
   font-size: 1rem;

--- a/src/components/layout/style.module.scss
+++ b/src/components/layout/style.module.scss
@@ -1,5 +1,5 @@
 @import "~flexbox-grid-mixins";
-@import "../../styles";
+@use "../../styles" as *;
 
 [data-reactroot] {
   position: relative;

--- a/src/components/link/_extension.scss
+++ b/src/components/link/_extension.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 %link {
   color: color(link-text);

--- a/src/components/link/style.module.scss
+++ b/src/components/link/style.module.scss
@@ -1,4 +1,4 @@
-@import "extension";
+@use "extension" as *;
 
 a.link {
   @extend %link;

--- a/src/components/loader/style.module.scss
+++ b/src/components/loader/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 // modified from: https://loading.io/css/
 
 .lds-ring {

--- a/src/components/markdown/index.jsx
+++ b/src/components/markdown/index.jsx
@@ -34,6 +34,11 @@ import {presetShape as genomeMapPresetShape} from '../genome-map';
 }*/
 
 
+/**
+ * ExtendedMarkdown renders markdown content with optional table of
+ * contents, reference links, and macro support. It wraps `react-markdown`
+ * and exposes additional hooks used throughout the application.
+ */
 function ExtendedMarkdown({
   noHeadingStyle,
   toc,

--- a/src/components/mutation/index.test.tsx
+++ b/src/components/mutation/index.test.tsx
@@ -1,9 +1,13 @@
+import React from 'react';
 import {render} from '@testing-library/react';
 import {describe, it, expect, vi} from 'vitest';
 import '@testing-library/jest-dom';
 
 vi.mock('../../utils/use-messages', () => ({
   default: () => ['<mutation-popup>', '', '', '', '', '']
+}));
+vi.mock('../markdown', () => ({
+  default: ({children}: {children: React.ReactNode}) => <>{children}</>
 }));
 
 import Mutation from './index';

--- a/src/components/mutation/style.module.scss
+++ b/src/components/mutation/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles/colors";
+@use "../../styles/colors" as *;
 
 
 .mutation-item {

--- a/src/components/mutations-input/style.module.scss
+++ b/src/components/mutations-input/style.module.scss
@@ -1,7 +1,7 @@
-@import "../../styles";
-@import "../../styles/tabs";
-@import "../../styles/dropdown";
-@import "../../styles/functions";
+@use "../../styles" as *;
+@use "../../styles/tabs" as *;
+@use "../../styles/dropdown" as *;
+@use "../../styles/functions" as *;
 
 
 .mutation-main-input-with-columns {

--- a/src/components/ngs2codfreq/options-form/style.module.scss
+++ b/src/components/ngs2codfreq/options-form/style.module.scss
@@ -1,5 +1,5 @@
-@import "../../../styles";
-@import "../../link/extension";
+@use "../../../styles" as *;
+@use "../../link/extension" as *;
 
 form.ngs-options-form {
   fieldset {

--- a/src/components/ngs2codfreq/style.module.scss
+++ b/src/components/ngs2codfreq/style.module.scss
@@ -1,6 +1,6 @@
-@import "../../styles";
-@import "../../styles/tabs";
-@import "../../styles/dropdown";
+@use "../../styles" as *;
+@use "../../styles/tabs" as *;
+@use "../../styles/dropdown" as *;
 
 label.input-label {
   @include inline-input-label(8rem);

--- a/src/components/paginator/style.module.scss
+++ b/src/components/paginator/style.module.scss
@@ -1,5 +1,5 @@
-@import "../../styles";
-@import "./variables";
+@use "../../styles" as *;
+@use "./variables" as *;
 
 .paginator-container {
   @extend %paginator-variables;

--- a/src/components/popup/style.module.scss
+++ b/src/components/popup/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles/popup";
+@use "../../styles/popup" as *;
 
 .icosa-popup {
   @include popup;

--- a/src/components/protein-viewer/style.module.scss
+++ b/src/components/protein-viewer/style.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/select';
+@use '../../styles/select' as *;
 .tooltip {
   display: none;
   position: fixed;

--- a/src/components/radio-input/style.module.scss
+++ b/src/components/radio-input/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 $radio-size: 1.28em;
 $radio-on-border-width: 0.36em;

--- a/src/components/references/style.module.scss
+++ b/src/components/references/style.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/colors';
+@use '../../styles/colors' as *;
 
 @keyframes highlight-ref-link {
   0% {

--- a/src/components/report/_ext.scss
+++ b/src/components/report/_ext.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 %report-section {
   margin: 2rem 1rem;

--- a/src/components/report/codon-coverage/style.module.scss
+++ b/src/components/report/codon-coverage/style.module.scss
@@ -1,4 +1,4 @@
-@import "../ext";
+@use "../ext" as *;
 
 .codon-reads-coverage {
   @extend %report-section;

--- a/src/components/report/dr-interpretation/style.module.scss
+++ b/src/components/report/dr-interpretation/style.module.scss
@@ -1,7 +1,7 @@
-@import "../ext";
-@import "../../../styles/tabs";
-@import "../../../styles/colors";
-@import "../../../styles/dropdown";
+@use "../ext" as *;
+@use "../../../styles/tabs" as *;
+@use "../../../styles/colors" as *;
+@use "../../../styles/dropdown" as *;
 
 
 .dr-report-mutation-by-types {

--- a/src/components/report/mutation-list/style.module.scss
+++ b/src/components/report/mutation-list/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/colors";
+@use "../../../styles/colors" as *;
 
 ul.mutation-list {
   padding-left: 1.5rem;

--- a/src/components/report/mutation-stats/style.module.scss
+++ b/src/components/report/mutation-stats/style.module.scss
@@ -1,5 +1,5 @@
 @use "sass:math";
-@import "../ext";
+@use "../ext" as *;
 
 .report-mutation-stats {
   @extend %report-section;

--- a/src/components/report/mutation-viewer/style.module.scss
+++ b/src/components/report/mutation-viewer/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/dropdown";
+@use "../../../styles/dropdown" as *;
 
 .sierra-genome-map-tabs {
   --tab-width: 10rem !important;

--- a/src/components/report/report-header/style.module.scss
+++ b/src/components/report/report-header/style.module.scss
@@ -1,4 +1,4 @@
-@import '../../../styles/colors';
+@use '../../../styles/colors' as *;
 
 header.report-header {
   color: color(seq-title);

--- a/src/components/report/report-paginator/style.module.scss
+++ b/src/components/report/report-paginator/style.module.scss
@@ -1,6 +1,6 @@
-@import "../../../styles/colors";
-@import "../../../styles/select";
-@import "../../paginator/variables";
+@use "../../../styles/colors" as *;
+@use "../../../styles/select" as *;
+@use "../../paginator/variables" as *;
 
 .report-paginator-container {
   position: sticky !important;

--- a/src/components/report/report-section/style.module.scss
+++ b/src/components/report/report-section/style.module.scss
@@ -1,4 +1,4 @@
-@import "../ext";
+@use "../ext" as *;
 
 .report-section {
   @extend %report-section;

--- a/src/components/report/seq-mutation-prevalence/style.module.scss
+++ b/src/components/report/seq-mutation-prevalence/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../../styles/colors";
+@use "../../../styles/colors" as *;
 
 .gene-mutation-prevalence {
 

--- a/src/components/report/seq-summary/style.module.scss
+++ b/src/components/report/seq-summary/style.module.scss
@@ -1,9 +1,9 @@
-@import "../ext";
-@import "../../../styles/tabs";
-@import "../../../styles/mixins";
-@import "../../../styles/colors";
-@import "../../../styles/dropdown";
-@import "../../../styles/functions";
+@use "../ext" as *;
+@use "../../../styles/tabs" as *;
+@use "../../../styles/mixins" as *;
+@use "../../../styles/colors" as *;
+@use "../../../styles/dropdown" as *;
+@use "../../../styles/functions" as *;
 
 .seq-summary {
   @extend %report-section;

--- a/src/components/report/seqreads-qa/style.module.scss
+++ b/src/components/report/seqreads-qa/style.module.scss
@@ -1,4 +1,4 @@
-@import "../ext";
+@use "../ext" as *;
 
 .report-seqreads-qa {
   @extend %report-section;

--- a/src/components/report/sequence-qa/style.module.scss
+++ b/src/components/report/sequence-qa/style.module.scss
@@ -1,4 +1,4 @@
-@import "../ext";
+@use "../ext" as *;
 
 .report-sequence-qa {
   @extend %report-section;

--- a/src/components/report/style.module.scss
+++ b/src/components/report/style.module.scss
@@ -1,7 +1,7 @@
-@import "./ext";
-@import "../../styles/tabs";
-@import "../../styles/colors";
-@import "../../styles/dropdown";
+@use "./ext" as *;
+@use "../../styles/tabs" as *;
+@use "../../styles/colors" as *;
+@use "../../styles/dropdown" as *;
 
 .link-style {
   color: color(link-text);

--- a/src/components/sars2-mutation-comments/style.module.scss
+++ b/src/components/sars2-mutation-comments/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles/colors";
+@use "../../styles/colors" as *;
 
 .mutation-comments-container {
   border: 1px solid color(dividing-line);

--- a/src/components/sidebar/index.test.tsx
+++ b/src/components/sidebar/index.test.tsx
@@ -9,8 +9,8 @@ describe('Sidebar', () => {
   it('marks current selected item', () => {
     const {container} = render(
       <Sidebar title="Title" currentSelected="a">
-        <SidebarItem name="a" to="/a">Item A</SidebarItem>
-        <SidebarItem name="b" to="/b">Item B</SidebarItem>
+        <SidebarItem name="a" href="/a">Item A</SidebarItem>
+        <SidebarItem name="b" href="/b">Item B</SidebarItem>
       </Sidebar>
     );
     const current = container.querySelector(`.${style.current}`);

--- a/src/components/sidebar/style.module.scss
+++ b/src/components/sidebar/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 .sidebar-sticky-container {
   position: sticky;

--- a/src/components/simple-table/style.module.scss
+++ b/src/components/simple-table/style.module.scss
@@ -1,5 +1,5 @@
-@import "../../styles/constants";
-@import "../../styles/functions";
+@use "../../styles/constants" as *;
+@use "../../styles/functions" as *;
 
 $header-bgcolor: #f9fafb;
 $header-bgcolor-hover: #f3f3f3;

--- a/src/components/sir-pcnt-bar/style.module.scss
+++ b/src/components/sir-pcnt-bar/style.module.scss
@@ -1,6 +1,6 @@
-@import "../../styles/colors";
-@import "../../styles/functions";
-@import "../../styles/extension";
+@use "../../styles/colors" as *;
+@use "../../styles/functions" as *;
+@use "../../styles/extension" as *;
 
 ul.sir-pcnt-bar {
   --bar-width: 30rem;

--- a/src/components/smooth-progress-bar/style.module.scss
+++ b/src/components/smooth-progress-bar/style.module.scss
@@ -1,4 +1,4 @@
-@import "../../styles";
+@use "../../styles" as *;
 
 .progress-bar-container {
   &[data-loaded="true"] {

--- a/src/components/susc-summary/style.module.scss
+++ b/src/components/susc-summary/style.module.scss
@@ -1,8 +1,8 @@
-@import "../../styles/colors";
-@import "../../styles/constants";
-@import "../../styles/functions";
-@import "../../styles/extension";
-@import "../../styles/popup";
+@use "../../styles/colors" as *;
+@use "../../styles/constants" as *;
+@use "../../styles/functions" as *;
+@use "../../styles/extension" as *;
+@use "../../styles/popup" as *;
 
 
 $cell-padding: .1rem;

--- a/src/components/vertical-tabs-style/style.module.scss
+++ b/src/components/vertical-tabs-style/style.module.scss
@@ -1,4 +1,4 @@
-@import '../../styles/colors';
+@use '../../styles/colors' as *;
 
 .vertical-tabs {
   --tab-width: 5rem;
@@ -8,11 +8,11 @@
   --ribbon-width: .5rem;
   --border-width: 1px;
   --toggler-width: 2.5rem;
+  display: grid;
+  grid-template-columns: var(--tab-width) auto;
   @media (min-resolution: 2dppx) {
     --border-width: .5px;
   }
-  display: grid;
-  grid-template-columns: var(--tab-width) auto;
 
   &[data-tabs-expanded="false"] {
     grid-template-columns: auto;

--- a/src/index.module.scss
+++ b/src/index.module.scss
@@ -1,4 +1,4 @@
-@import "./styles/default-colors";
+@use "./styles/default-colors" as *;
 
 body {
   @include default-color;

--- a/src/shims/ramda-src-forEach.js
+++ b/src/shims/ramda-src-forEach.js
@@ -1,0 +1,6 @@
+// Shim for libraries that still require Ramda's deprecated
+// "src" entry point. Re-export the function from the ESM build
+// so tooling can resolve it without touching the unexported
+// internal module.
+import forEach from 'ramda/es/forEach.js';
+export default forEach;

--- a/src/styles/_dropdown.scss
+++ b/src/styles/_dropdown.scss
@@ -1,4 +1,4 @@
-@import "./colors";
+@use "./colors" as *;
 
 %base-dropdown {
   :global {

--- a/src/styles/_extension.scss
+++ b/src/styles/_extension.scss
@@ -1,4 +1,5 @@
-@import "./colors";
+@use "./colors" as *;
+@use "./constants" as *;
 
 %hide-text {
   text-indent: 100%;

--- a/src/styles/_functions.scss
+++ b/src/styles/_functions.scss
@@ -1,4 +1,4 @@
-@import "./constants";
+@use "./constants" as *;
 
 /// Remove the unit of a length
 /// @param {Number} $number - Number to remove unit from

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -1,5 +1,0 @@
-@import "./constants";
-@import "./colors";
-@import "./extension";
-@import "./mixins";
-@import "./functions";

--- a/src/styles/_select.scss
+++ b/src/styles/_select.scss
@@ -1,4 +1,4 @@
-@import "./colors";
+@use "./colors" as *;
 
 @mixin select($class-name-prefix) {
   :global .#{$class-name-prefix}__control {

--- a/src/styles/_table.scss
+++ b/src/styles/_table.scss
@@ -1,4 +1,4 @@
-@import "./colors";
+@use "./colors" as *;
 
 %table-style {
   table {

--- a/src/styles/_tabs.scss
+++ b/src/styles/_tabs.scss
@@ -1,4 +1,4 @@
-@import "./colors";
+@use "./colors" as *;
 
 %react-tabs-container {
   :global {

--- a/src/styles/content.scss
+++ b/src/styles/content.scss
@@ -1,5 +1,5 @@
-@import "./colors";
-@import "./table";
+@use "./colors" as *;
+@use "./table" as *;
 
 :local .content-container {
   @extend %table-style;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -1,6 +1,6 @@
 @import "~normalize-scss";
-@import "./colors";
-@import "./constants";
+@use "./colors" as *;
+@use "./constants" as *;
 
 @include normalize();
 

--- a/src/styles/griddle-table.scss
+++ b/src/styles/griddle-table.scss
@@ -1,5 +1,5 @@
-@import "./colors";
-@import "./table";
+@use "./colors" as *;
+@use "./table" as *;
 
 .griddle-container {
   line-height: 1.5;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,0 +1,5 @@
+@forward "./constants";
+@forward "./colors";
+@forward "./extension";
+@forward "./mixins";
+@forward "./functions";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -9,6 +10,14 @@ export default defineConfig({
   },
   server: {
     port: 3009
+  },
+  resolve: {
+    alias: {
+      // Ramda's ESM build does not expose "src" to the exports
+      // field. Provide a shim so dependencies requesting
+      // "ramda/src/forEach" continue to work under vitest.
+      'ramda/src/forEach': path.resolve(__dirname, 'src/shims/ramda-src-forEach.js')
+    }
   },
   test: {
     globals: true,


### PR DESCRIPTION
## Summary
- replace deprecated Sass @import statements with @use and @forward
- add shim for ramda src subpath and alias in vite config
- adjust Sidebar test to avoid router context

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688ea4456f0c8324887b69574e859a0c