### PR TITLE
refactor: convert seqreads threshold nomogram to ts

### DIFF
--- a/src/components/seqreads-threshold-nomogram/actual-threshold.tsx
+++ b/src/components/seqreads-threshold-nomogram/actual-threshold.tsx
@@ -1,25 +1,33 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import constants from './constants';
+import type {ScaleFn} from './types';
 
 const MAIN_COLOR = '#ba6000';
 
+export interface ActualThresholdProps {
+  /** Applied nucleotide mixture threshold on the X axis. */
+  thresholdX: number;
+  /** Applied mutation detection threshold on the Y axis. */
+  thresholdY: number;
+  /** Scaling function for the X axis. */
+  scaleX: ScaleFn;
+  /** Scaling function for the Y axis. */
+  scaleY: ScaleFn;
+}
 
-ActualThreshold.propTypes = {
-  thresholdX: PropTypes.number.isRequired,
-  thresholdY: PropTypes.number.isRequired,
-  scaleX: PropTypes.func.isRequired,
-  scaleY: PropTypes.func.isRequired
-};
-
-
+/**
+ * Render a pointer highlighting the actual thresholds applied on the nomogram.
+ *
+ * @param props - {@link ActualThresholdProps} specifying thresholds and scales.
+ * @returns SVG group containing the marker, circle and text labels.
+ */
 export default function ActualThreshold({
   thresholdX,
   thresholdY,
   scaleX,
   scaleY
-}) {
+}: ActualThresholdProps) {
   const cx = scaleX(thresholdX);
   const cy = scaleY(thresholdY);
   const {

--- a/src/components/seqreads-threshold-nomogram/constants.ts
+++ b/src/components/seqreads-threshold-nomogram/constants.ts
@@ -1,3 +1,7 @@
+/**
+ * Collection of layout and styling constants used across the sequencing
+ * threshold nomogram components.
+ */
 const constants = {
   paddingV: 20,
   paddingH: 20,
@@ -14,6 +18,6 @@ const constants = {
   actualThresholdRadius: 6,
   actualThresholdArrowLineSize: 25,
   actualThresholdFontSize: 28
-};
+} as const;
 
 export default constants;

--- a/src/components/seqreads-threshold-nomogram/cutoff-curve.tsx
+++ b/src/components/seqreads-threshold-nomogram/cutoff-curve.tsx
@@ -1,43 +1,48 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-
-import {line, /*curveMonotoneX, */curveStepBefore} from 'd3-shape';
+import {line, curveStepBefore} from 'd3-shape';
 
 import constants from './constants';
+import type {CutoffKeyPoint, ScaleFn} from './types';
 
+interface CutoffCurveProps {
+  /** Key points describing the cutoff curve. */
+  cutoffKeyPoints: CutoffKeyPoint[];
+  /** Scaling function for mixture rate (X axis). */
+  mixtureRateScale: ScaleFn;
+  /** Scaling function for minimum prevalence (Y axis). */
+  minPrevalenceScale: ScaleFn;
+}
 
-function useCalcCutoffCurve({mixtureRateScale, minPrevalenceScale}) {
+/**
+ * Create a memoized D3 line generator for drawing the cutoff curve.
+ *
+ * @param options - Scaling functions for X and Y axes.
+ * @returns The configured D3 line generator.
+ */
+function useCalcCutoffCurve({mixtureRateScale, minPrevalenceScale}: {
+  mixtureRateScale: ScaleFn;
+  minPrevalenceScale: ScaleFn;
+}) {
   return React.useMemo(
-    () => line()
+    () => line<CutoffKeyPoint>()
       .curve(curveStepBefore)
-      // .curve(curveMonotoneX)
       .x(d => mixtureRateScale(d.mixtureRate))
       .y(d => minPrevalenceScale(d.minPrevalence)),
     [minPrevalenceScale, mixtureRateScale]
   );
 }
 
-
-const CutoffKeyPoint = PropTypes.shape({
-  mixtureRate: PropTypes.number.isRequired,
-  minPrevalence: PropTypes.number.isRequired
-});
-
-
-CutoffCurve.propTypes = {
-  cutoffKeyPoints: PropTypes.arrayOf(
-    CutoffKeyPoint.isRequired
-  ).isRequired,
-  mixtureRateScale: PropTypes.func.isRequired,
-  minPrevalenceScale: PropTypes.func.isRequired
-};
-
-
+/**
+ * Render the cutoff curve showing the valid threshold area.
+ *
+ * @param props - {@link CutoffCurveProps} defining key points and scales.
+ * @returns SVG group containing the cutoff path.
+ */
 export default function CutoffCurve({
   cutoffKeyPoints,
   mixtureRateScale,
   minPrevalenceScale
-}) {
+}: CutoffCurveProps) {
   const calcCutoffCurve = useCalcCutoffCurve({
     mixtureRateScale,
     minPrevalenceScale
@@ -54,7 +59,7 @@ export default function CutoffCurve({
           d.minPrevalence <= prevalenceDomain[1]
         )
       );
-      return calcCutoffCurve(keyPoints);
+      return calcCutoffCurve(keyPoints) ?? undefined;
     },
     [calcCutoffCurve, cutoffKeyPoints, mixtureRateDomain, prevalenceDomain]
   );
@@ -67,7 +72,7 @@ export default function CutoffCurve({
           d.minPrevalence < prevalenceDomain[0]
         )
       );
-      return calcCutoffCurve(keyPoints);
+      return calcCutoffCurve(keyPoints) ?? undefined;
     },
     [calcCutoffCurve, cutoffKeyPoints, mixtureRateDomain, prevalenceDomain]
   );

--- a/src/components/seqreads-threshold-nomogram/index.test.tsx
+++ b/src/components/seqreads-threshold-nomogram/index.test.tsx
@@ -1,0 +1,116 @@
+import {render, screen, renderHook} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
+import '@testing-library/jest-dom';
+
+import SeqReadsThresholdNomogram from './index';
+import ActualThreshold from './actual-threshold';
+import CutoffCurve from './cutoff-curve';
+import MixtureRateAxis, {useMixtureRateScale} from './mixture-rate-axis';
+import MinPrevalenceAxis, {useMinPrevalenceScale} from './min-prevalence-axis';
+import ThresholdLine from './threshold-line';
+import constants from './constants';
+
+const cutoffPoints = [
+  {mixtureRate: 0, minPrevalence: 0},
+  {mixtureRate: 0.01, minPrevalence: 0.1},
+  {mixtureRate: 0.02, minPrevalence: 0.2}
+];
+
+describe('SeqReadsThresholdNomogram suite', () => {
+  it('renders full nomogram with applied thresholds', () => {
+    render(
+      <SeqReadsThresholdNomogram
+       cutoffKeyPoints={cutoffPoints}
+       mixtureRateThreshold={0.01}
+       minPrevalenceThreshold={0.1}
+       mixtureRateActual={0.005}
+       minPrevalenceActual={0.05}
+      />
+    );
+    expect(screen.getByText(/Applied thresholds/)).toBeInTheDocument();
+  });
+
+  it('generates increasing mixture rate scale', () => {
+    const {result} = renderHook(() => (
+      useMixtureRateScale({width: 200, mixtureRateTicks: [0, 0.1, 0.2]})
+    ));
+    expect(result.current(0.2)).toBeGreaterThan(result.current(0.1));
+  });
+
+  it('generates decreasing min prevalence scale', () => {
+    const {result} = renderHook(() => (
+      useMinPrevalenceScale({height: 200, minPrevalenceDomain: [0, 0.3]})
+    ));
+    expect(result.current(0.3)).toBeLessThan(result.current(0.1));
+  });
+
+  it('renders axes with tick labels', () => {
+    const mixScale = renderHook(() => (
+      useMixtureRateScale({width: 200, mixtureRateTicks: [0, 0.1, 0.2]})
+    )).result.current;
+    const prevScale = renderHook(() => (
+      useMinPrevalenceScale({height: 200, minPrevalenceDomain: [0, 0.2]})
+    )).result.current;
+    const {getAllByText} = render(
+      <svg>
+        <MixtureRateAxis scale={mixScale} height={200} ticks={[0, 0.1, 0.2]} />
+        <MinPrevalenceAxis scale={prevScale} ticks={[0, 0.1, 0.2]} />
+      </svg>
+    );
+    expect(getAllByText('10%').length).toBeGreaterThan(0);
+    expect(getAllByText('20%').length).toBeGreaterThan(0);
+  });
+
+  it('renders cutoff curve and threshold line', () => {
+    const mixScale = renderHook(() => (
+      useMixtureRateScale({width: 200, mixtureRateTicks: [0, 0.02]})
+    )).result.current;
+    const prevScale = renderHook(() => (
+      useMinPrevalenceScale({height: 200, minPrevalenceDomain: [0, 0.2]})
+    )).result.current;
+    const {container} = render(
+      <svg>
+        <CutoffCurve
+         cutoffKeyPoints={cutoffPoints}
+         mixtureRateScale={mixScale}
+         minPrevalenceScale={prevScale}
+        />
+        <ThresholdLine
+         direction="vertical"
+         threshold={0.01}
+         thresholdCmp="<"
+         scaleX={mixScale}
+         scaleY={prevScale}
+         color="#000"
+        />
+      </svg>
+    );
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+    expect(container.querySelector('line')).toBeInTheDocument();
+  });
+
+  it('renders actual threshold indicator', () => {
+    const mixScale = renderHook(() => (
+      useMixtureRateScale({width: 200, mixtureRateTicks: [0, 0.02]})
+    )).result.current;
+    const prevScale = renderHook(() => (
+      useMinPrevalenceScale({height: 200, minPrevalenceDomain: [0, 0.2]})
+    )).result.current;
+    const {container, getByText} = render(
+      <svg>
+        <ActualThreshold
+         thresholdX={0.01}
+         thresholdY={0.1}
+         scaleX={mixScale}
+         scaleY={prevScale}
+        />
+      </svg>
+    );
+    expect(container.querySelector('circle')).toBeInTheDocument();
+    expect(getByText(/Applied thresholds/)).toBeInTheDocument();
+  });
+
+  it('exposes constant values', () => {
+    expect(constants.actualThresholdRadius).toBeGreaterThan(0);
+  });
+});

--- a/src/components/seqreads-threshold-nomogram/index.tsx
+++ b/src/components/seqreads-threshold-nomogram/index.tsx
@@ -1,59 +1,55 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import CutoffCurve from './cutoff-curve';
 import MixtureRateAxis, {useMixtureRateScale} from './mixture-rate-axis';
 import MinPrevalenceAxis, {useMinPrevalenceScale} from './min-prevalence-axis';
 import ThresholdLine from './threshold-line';
 import ActualThreshold from './actual-threshold';
+import type {CutoffKeyPoint} from './types';
 
+export type {CutoffKeyPoint} from './types';
 
-export const CutoffKeyPoint = PropTypes.shape({
-  mixtureRate: PropTypes.number.isRequired,
-  minPrevalence: PropTypes.number.isRequired,
-  isAboveMixtureRateThreshold: PropTypes.bool.isRequired,
-  isBelowMinPrevalenceThreshold: PropTypes.bool.isRequired
-});
+export interface SeqReadsThresholdNomogramProps {
+  /** Key points outlining the cutoff curve. */
+  cutoffKeyPoints: CutoffKeyPoint[];
+  /** Threshold value on the mixture rate axis. */
+  mixtureRateThreshold: number;
+  /** Threshold value on the minimum prevalence axis. */
+  minPrevalenceThreshold: number;
+  /** Actual mixture rate applied in analysis. */
+  mixtureRateActual: number;
+  /** Actual minimum prevalence applied in analysis. */
+  minPrevalenceActual: number;
+  /** Width of the SVG canvas. */
+  width?: number;
+  /** Height of the SVG canvas. */
+  height?: number;
+  /** Tick marks for the mixture rate axis. */
+  mixtureRateTicks?: number[];
+  /** Tick marks for the minimum prevalence axis. */
+  minPrevalenceTicks?: number[];
+}
 
-
-SeqReadsThresholdNomogram.propTypes = {
-  cutoffKeyPoints: PropTypes.arrayOf(
-    CutoffKeyPoint.isRequired
-  ).isRequired,
-  mixtureRateThreshold: PropTypes.number.isRequired,
-  minPrevalenceThreshold: PropTypes.number.isRequired,
-  mixtureRateActual: PropTypes.number.isRequired,
-  minPrevalenceActual: PropTypes.number.isRequired,
-  width: PropTypes.number.isRequired,
-  height: PropTypes.number.isRequired,
-  mixtureRateTicks: PropTypes.arrayOf(
-    PropTypes.number.isRequired
-  ).isRequired,
-  minPrevalenceTicks: PropTypes.arrayOf(
-    PropTypes.number.isRequired
-  ).isRequired
-
-};
-
-SeqReadsThresholdNomogram.defaultProps = {
-  width: 800,
-  height: 400,
-  mixtureRateTicks: [0, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02],
-  minPrevalenceTicks: [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3]
-};
-
-
+/**
+ * Visualize thresholds for sequencing reads using a nomogram. The diagram shows
+ * the relationship between nucleotide mixture and mutation detection thresholds
+ * with annotated cutoff curves and actual applied thresholds.
+ *
+ * @param props - {@link SeqReadsThresholdNomogramProps} controlling data and
+ *   rendering parameters.
+ * @returns An SVG element rendering the nomogram.
+ */
 export default function SeqReadsThresholdNomogram({
   cutoffKeyPoints,
   mixtureRateThreshold,
   minPrevalenceThreshold,
   mixtureRateActual,
   minPrevalenceActual,
-  width,
-  height,
-  mixtureRateTicks,
-  minPrevalenceTicks
-}) {
+  width = 800,
+  height = 400,
+  mixtureRateTicks = [0, 0.0005, 0.001, 0.002, 0.005, 0.01, 0.02],
+  minPrevalenceTicks = [0, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3]
+}: SeqReadsThresholdNomogramProps) {
   const minPrevalenceDomain = React.useMemo(
     () => [Math.min(...minPrevalenceTicks), Math.max(...minPrevalenceTicks)],
     [minPrevalenceTicks]

--- a/src/components/seqreads-threshold-nomogram/min-prevalence-axis.tsx
+++ b/src/components/seqreads-threshold-nomogram/min-prevalence-axis.tsx
@@ -1,15 +1,27 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-
 import {scaleLinear} from 'd3-scale';
 
 import constants from './constants';
+import type {ScaleFn} from './types';
 
+export interface UseMinPrevalenceScaleOptions {
+  /** Height of the overall SVG canvas. */
+  height: number;
+  /** Domain for minimum prevalence values. */
+  minPrevalenceDomain: number[];
+}
 
+/**
+ * Generate a linear scale for the minimum prevalence axis.
+ *
+ * @param options - {@link UseMinPrevalenceScaleOptions} describing chart size
+ *   and domain.
+ * @returns A memoized scale function mapping prevalence to pixel positions.
+ */
 export function useMinPrevalenceScale({
   height,
   minPrevalenceDomain
-}) {
+}: UseMinPrevalenceScaleOptions): ScaleFn {
   const axisStart = (
     height -
     constants.paddingV -
@@ -20,19 +32,33 @@ export function useMinPrevalenceScale({
   );
   const axisEnd = constants.paddingV;
   return React.useMemo(
-    () => scaleLinear()
+    () => scaleLinear<number>()
       .domain(minPrevalenceDomain)
       .range([axisStart, axisEnd]),
     [axisEnd, axisStart, minPrevalenceDomain]
   );
 }
 
+interface AxisPathOptions {
+  /** Scale used for positioning. */
+  scale: ScaleFn;
+  /** X coordinate for the axis line. */
+  axisLeft: number;
+  /** Tick values to render. */
+  ticks: number[];
+}
 
+/**
+ * Compute SVG path data for rendering the Y axis and its ticks.
+ *
+ * @param options - {@link AxisPathOptions} describing scale and ticks.
+ * @returns SVG path data string.
+ */
 function useAxisPathData({
   scale,
   axisLeft,
   ticks
-}) {
+}: AxisPathOptions) {
   return React.useMemo(
     () => {
       const [y1, y2] = scale.range();
@@ -61,24 +87,33 @@ function useAxisPathData({
   );
 }
 
-
-function pcntFormat(value) {
+/**
+ * Format a number as a percentage string.
+ *
+ * @param value - Raw value between 0 and 1.
+ * @returns Formatted percentage string.
+ */
+function pcntFormat(value: number) {
   return `${(value * 100).toFixed(0)}%`;
 }
 
+interface MinPrevalenceAxisProps {
+  /** Scale function for the axis. */
+  scale: ScaleFn;
+  /** Tick values to render. */
+  ticks: number[];
+}
 
-MinPrevalenceAxis.propTypes = {
-  scale: PropTypes.func.isRequired,
-  ticks: PropTypes.arrayOf(
-    PropTypes.number.isRequired
-  ).isRequired
-};
-
-
+/**
+ * Render the Y axis representing mutation detection threshold.
+ *
+ * @param props - {@link MinPrevalenceAxisProps} defining scale and ticks.
+ * @returns SVG group element containing labels and axis line.
+ */
 export default function MinPrevalenceAxis({
   scale,
   ticks
-}) {
+}: MinPrevalenceAxisProps) {
   const axisLeft = (
     constants.paddingH +
     constants.axisTitleFontSize +

--- a/src/components/seqreads-threshold-nomogram/mixture-rate-axis.tsx
+++ b/src/components/seqreads-threshold-nomogram/mixture-rate-axis.tsx
@@ -1,15 +1,29 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-
 import {scaleLog} from 'd3-scale';
 
 import constants from './constants';
+import type {ScaleFn} from './types';
 
+export interface UseMixtureRateScaleOptions {
+  /** Width of the SVG canvas. */
+  width: number;
+  /** Tick values for the mixture rate axis. */
+  mixtureRateTicks: number[];
+}
 
+/**
+ * Generate a logarithmic-like scale for the mixture rate axis.
+ * The function adjusts the domain so that zero can be represented by shifting
+ * values before applying a log transformation.
+ *
+ * @param options - {@link UseMixtureRateScaleOptions} describing canvas width
+ *   and tick configuration.
+ * @returns A memoized scale function for mixture rate values.
+ */
 export function useMixtureRateScale({
   width,
   mixtureRateTicks
-}) {
+}: UseMixtureRateScaleOptions): ScaleFn {
   const axisStart = (
     constants.paddingH +
     constants.axisTitleFontSize +
@@ -27,25 +41,39 @@ export function useMixtureRateScale({
       const nonZeroMinTick = Math.min(...mixtureRateTicks.filter(n => n > 0));
       const level = 0.2 * 10 ** -Math.floor(Math.log10(nonZeroMinTick));
 
-      const baseScale = scaleLog()
+      const baseScale = scaleLog<number>()
         .base(10)
         .domain(mixtureRateDomain.map(n => n * level + 1))
         .range([axisStart, axisEnd]);
-      const scale = value => baseScale(value * level + 1);
+      const scale = ((value: number) => baseScale(value * level + 1)) as ScaleFn;
       scale.domain = () => baseScale.domain().map(n => (n - 1) / level);
-      scale.range = baseScale.range;
+      scale.range = baseScale.range.bind(baseScale);
       return scale;
     },
     [axisStart, axisEnd, mixtureRateTicks]
   );
 }
 
+interface AxisPathOptions {
+  /** Scale for positioning. */
+  scale: ScaleFn;
+  /** Y coordinate for the axis line. */
+  axisTop: number;
+  /** Tick values. */
+  ticks: number[];
+}
 
+/**
+ * Calculate the SVG path for the X axis including tick marks.
+ *
+ * @param options - {@link AxisPathOptions} with scale and tick details.
+ * @returns SVG path data string.
+ */
 function useAxisPathData({
   scale,
   axisTop,
   ticks
-}) {
+}: AxisPathOptions) {
   return React.useMemo(
     () => {
       const [x1, x2] = scale.range();
@@ -74,8 +102,13 @@ function useAxisPathData({
   );
 }
 
-
-function pcntFormat(value) {
+/**
+ * Format mixture rate values as percentages with adaptive precision.
+ *
+ * @param value - Raw value between 0 and 1.
+ * @returns Percentage string with 0-1 decimal places.
+ */
+function pcntFormat(value: number) {
   if (value < 0.1) {
     return `${(value * 100).toPrecision(1)}%`;
   }
@@ -84,21 +117,26 @@ function pcntFormat(value) {
   }
 }
 
+interface MixtureRateAxisProps {
+  /** Scale function for the axis. */
+  scale: ScaleFn;
+  /** Height of the overall SVG canvas. */
+  height: number;
+  /** Tick values to render. */
+  ticks: number[];
+}
 
-MixtureRateAxis.propTypes = {
-  scale: PropTypes.func.isRequired,
-  height: PropTypes.number.isRequired,
-  ticks: PropTypes.arrayOf(
-    PropTypes.number.isRequired
-  ).isRequired
-};
-
-
+/**
+ * Render the X axis representing nucleotide mixture threshold.
+ *
+ * @param props - {@link MixtureRateAxisProps} defining scale and ticks.
+ * @returns SVG group element containing labels and axis line.
+ */
 export default function MixtureRateAxis({
   scale,
   height,
   ticks
-}) {
+}: MixtureRateAxisProps) {
   const axisTop = (
     height -
     constants.paddingV -

--- a/src/components/seqreads-threshold-nomogram/threshold-line.tsx
+++ b/src/components/seqreads-threshold-nomogram/threshold-line.tsx
@@ -1,45 +1,53 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
 import constants from './constants';
+import type {ScaleFn} from './types';
 
+export interface ThresholdLineProps {
+  /** Orientation of the threshold line. */
+  direction: 'horizontal' | 'vertical';
+  /** Scaling function for the X axis. */
+  scaleX: ScaleFn;
+  /** Scaling function for the Y axis. */
+  scaleY: ScaleFn;
+  /** Numerical threshold value. */
+  threshold: number;
+  /** Comparison operator determining the filled side of the line. */
+  thresholdCmp: '>' | '<';
+  /** Stroke dash pattern for the line. */
+  strokeDasharray?: string;
+  /** Color used for the line and gradient. */
+  color: string;
+}
 
-ThresholdLine.propTypes = {
-  direction: PropTypes.oneOf(['horizontal', 'vertical']).isRequired,
-  scaleX: PropTypes.func.isRequired,
-  scaleY: PropTypes.func.isRequired,
-  threshold: PropTypes.number.isRequired,
-  thresholdCmp: PropTypes.oneOf(['>', '<']).isRequired,
-  strokeDasharray: PropTypes.string.isRequired,
-  color: PropTypes.string.isRequired
-};
-
-
-ThresholdLine.defaultProps = {
-  strokeDasharray: '5,5'
-};
-
-
+/**
+ * Render a threshold line indicating a limit on either axis. A translucent
+ * rectangle fills the invalid side of the threshold.
+ *
+ * @param props - {@link ThresholdLineProps} specifying orientation, threshold
+ *   and styling options.
+ * @returns SVG group containing the line and its gradient fill.
+ */
 export default function ThresholdLine({
   direction,
   scaleX,
   scaleY,
   threshold,
   thresholdCmp,
-  strokeDasharray,
+  strokeDasharray = '5,5',
   color
-}) {
+}: ThresholdLineProps) {
   const uniqId = `threshold-${direction}-${thresholdCmp}${threshold}`;
-  const lineProps = {
+  const lineProps: React.SVGProps<SVGLineElement> = {
     strokeDasharray,
     stroke: color,
     strokeWidth: constants.strokeWidth
   };
-  const rectProps = {
+  const rectProps: React.SVGProps<SVGRectElement> = {
     fill: `url(#${uniqId})`,
     opacity: .2
   };
-  const gradientProps = {id: uniqId};
+  const gradientProps: React.SVGProps<SVGLinearGradientElement> = {id: uniqId};
   if (direction === 'horizontal') {
     lineProps.y1 = scaleY(threshold);
     lineProps.y2 = lineProps.y1;
@@ -50,13 +58,13 @@ export default function ThresholdLine({
     gradientProps.x2 = 0;
     if (thresholdCmp === '>') {
       rectProps.y = scaleY.range()[1];
-      rectProps.height = lineProps.y1 - rectProps.y;
+      rectProps.height = lineProps.y1 - (rectProps.y as number);
       gradientProps.y1 = 1;
       gradientProps.y2 = 0;
     }
     else {
       rectProps.y = lineProps.y1;
-      rectProps.height = scaleY.range()[0] - rectProps.y;
+      rectProps.height = scaleY.range()[0] - (rectProps.y as number);
       gradientProps.y1 = 0;
       gradientProps.y2 = 1;
     }
@@ -71,13 +79,13 @@ export default function ThresholdLine({
     gradientProps.y2 = 0;
     if (thresholdCmp === '>') {
       rectProps.x = lineProps.x1;
-      rectProps.width = scaleX.range()[1] - rectProps.x;
+      rectProps.width = scaleX.range()[1] - (rectProps.x as number);
       gradientProps.x1 = 0;
       gradientProps.x2 = 1;
     }
     else {
       rectProps.x = scaleX.range()[0];
-      rectProps.width = lineProps.x1 - rectProps.x;
+      rectProps.width = lineProps.x1 - (rectProps.x as number);
       gradientProps.x2 = 0;
       gradientProps.x1 = 1;
     }

--- a/src/components/seqreads-threshold-nomogram/types.ts
+++ b/src/components/seqreads-threshold-nomogram/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Definition of a generic numeric scale function similar to D3 scales.
+ *
+ * @param value - Numeric input value to be scaled.
+ * @returns The scaled numeric output value.
+ */
+export interface ScaleFn {
+  (value: number): number;
+  /**
+   * Get the current domain of the scale.
+   * @returns Two-element array representing the input domain.
+   */
+  domain(): number[];
+  /**
+   * Get the current range of the scale.
+   * @returns Two-element array representing the output range.
+   */
+  range(): number[];
+}
+
+/**
+ * A key point describing the relationship between mixture rate and minimum
+ * prevalence thresholds.
+ */
+export interface CutoffKeyPoint {
+  /** Mixture rate at the key point. */
+  mixtureRate: number;
+  /** Minimum prevalence at the key point. */
+  minPrevalence: number;
+  /** Whether the mixture rate is above the threshold line. */
+  isAboveMixtureRateThreshold?: boolean;
+  /** Whether the prevalence is below the threshold line. */
+  isBelowMinPrevalenceThreshold?: boolean;
+}


### PR DESCRIPTION
## Summary
- convert seqreads threshold nomogram and subcomponents to TypeScript with hooks and interfaces
- add comprehensive tests for nomogram scales and rendering

## Testing
- `yarn test src/components/seqreads-threshold-nomogram/index.test.tsx --no-file-parallelism`
- `yarn test --no-file-parallelism`


------
https://chatgpt.com/codex/tasks/task_e_688fe914d4548324bcd875773d7dc1e7