### PR TITLE
refactor: improve tabular report handling

### DIFF
--- a/src/components/report/report-header/index.tsx
+++ b/src/components/report/report-header/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import style from './style.module.scss';
+import {ObservePayload} from '../../../utils/use-scroll-observer';
 
 /**
  * Highlight the first word of a section title.
@@ -72,16 +73,6 @@ function ReportHeader({
       <HLFirstWord index={index}>{name}</HLFirstWord>
     </header>
   );
-}
-
-/** Payload used when observing or disconnecting a header. */
-export interface ObservePayload {
-  /** Section name. */
-  name: string;
-  /** Zero-based index. */
-  index: number;
-  /** Parent DOM node of the header. */
-  node: HTMLElement | null;
 }
 
 /** Props for {@link ReportHeader}. */

--- a/src/components/sequence-analysis-layout/index.tsx
+++ b/src/components/sequence-analysis-layout/index.tsx
@@ -40,14 +40,14 @@ export interface SequenceAnalysisContainerProps {
  * @param props - {@link SequenceAnalysisContainerProps} for the component.
  * @returns React element wrapping {@link SeqAnalysisQuery}.
  */
-export default function SequenceAnalysisContainer({
+const SequenceAnalysisContainer: React.FC<SequenceAnalysisContainerProps> = ({
   progressText = (progress, total) =>
     `Running sequence analysis... (${progress}/${total})`,
   onExtendVariables = (vars) => vars,
   renderPartialResults = true,
   quickLoadLimit = 2,
   ...props
-}: SequenceAnalysisContainerProps): JSX.Element {
+}: SequenceAnalysisContainerProps) => {
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
     console.debug('render SequenceAnalysisContainer', new Date().getTime());
@@ -64,29 +64,30 @@ export default function SequenceAnalysisContainer({
     children,
   } = props;
 
-  return (
-    <SeqAnalysisQuery
-      query={query}
-      lazyLoad={lazyLoad}
-      quickLoadLimit={quickLoadLimit}
-      renderPartialResults={renderPartialResults}
-      currentSelected={currentSelected}
-      showProgressBar={!renderPartialResults}
-      extraParams={extraParams}
-      client={client}
-      progressText={progressText}
-      onExtendVariables={onExtendVariables}
-      sequences={sequences}
-      maxPerRequest={maxPerRequest}
-      {...calcInitOffsetLimit({
-        size: sequences.length,
-        curIndex: currentSelected.index,
-        lazyLoad,
-        quickLoadLimit,
-      })}
-    >
-      {children}
-    </SeqAnalysisQuery>
-  );
-}
+    return (
+      <SeqAnalysisQuery
+        query={query}
+        lazyLoad={lazyLoad}
+        quickLoadLimit={quickLoadLimit}
+        renderPartialResults={renderPartialResults}
+        currentSelected={currentSelected}
+        showProgressBar={!renderPartialResults}
+        extraParams={extraParams}
+        client={client}
+        progressText={progressText}
+        onExtendVariables={onExtendVariables}
+        sequences={sequences}
+        maxPerRequest={maxPerRequest}
+        {...calcInitOffsetLimit({
+          size: sequences.length,
+          curIndex: currentSelected.index,
+          lazyLoad,
+          quickLoadLimit,
+        })}
+      >
+        {children}
+      </SeqAnalysisQuery>
+    );
+  };
 
+export default SequenceAnalysisContainer;

--- a/src/utils/use-scroll-observer.ts
+++ b/src/utils/use-scroll-observer.ts
@@ -26,10 +26,10 @@ interface Options {
   afterLoadNewItem: () => void;
 }
 
-interface ObservePayload {
+export interface ObservePayload {
   name: string;
   index: number;
-  node: HTMLElement;
+  node: HTMLElement | null;
 }
 
 /**
@@ -95,7 +95,7 @@ export default function useScrollObserver({
       self.current.previousYs[name] = currentY;
       self.current.previousRatios[name] = currentRatio;
       return {
-        node: self.current.observingNodes[name],
+        node: self.current.observingNodes[name] || null,
         direction,
         name,
         index
@@ -117,7 +117,7 @@ export default function useScrollObserver({
       let observedNodes = entries
         .map(getNodeAndDirection)
         .filter(({direction}) => !!direction) as Array<{
-          node: HTMLElement;
+          node: HTMLElement | null;
           name: string;
           index: number;
           direction: string | null;
@@ -130,7 +130,9 @@ export default function useScrollObserver({
 
       for (const {node, name} of observedNodes) {
         await asyncLoadNewItem(name, /* updateCurrentSelected = */true);
-        node.dataset.scrollObserveLoaded = 'yes';
+        if (node) {
+          node.dataset.scrollObserveLoaded = 'yes';
+        }
         break;
       }
       afterLoadNewItem();
@@ -213,6 +215,9 @@ export default function useScrollObserver({
 
   const onObserve = React.useCallback(
     ({name, index, node}: ObservePayload) => {
+      if (!node) {
+        return;
+      }
       node.dataset.scrollObserveName = name;
       node.dataset.scrollObserveIndex = String(index);
       self.current.observingNodes[name] = node;
@@ -224,7 +229,10 @@ export default function useScrollObserver({
   );
 
   const onDisconnect = React.useCallback(
-    ({node}: {node: HTMLElement}) => {
+    ({node}: ObservePayload) => {
+      if (!node) {
+        return;
+      }
       const name = node.dataset.scrollObserveName as string;
       delete self.current.observingNodes[name];
     },

--- a/src/views/sars2/report-by-reads/reports.tsx
+++ b/src/views/sars2/report-by-reads/reports.tsx
@@ -52,13 +52,13 @@ interface SeqReadsReportsProps {
   /** Analysis results for each sequence read. */
   sequenceReadsAnalysis: any[];
   /** Callback to fetch additional results. */
-  fetchAnother: () => void;
+  fetchAnother: (name: string, updateCurrentSelected: boolean) => Promise<void>;
 }
 
 /**
  * Render sequence reads analysis reports with pagination.
  */
-function SeqReadsReports({
+const SeqReadsReports: React.FC<SeqReadsReportsProps> = ({
   output,
   cmtVersion,
   antibodies = [],
@@ -70,7 +70,7 @@ function SeqReadsReports({
   currentSelected,
   sequenceReadsAnalysis,
   fetchAnother
-}: SeqReadsReportsProps): JSX.Element {
+}: SeqReadsReportsProps) => {
 
   const numSeqs = allSequenceReads.length;
 
@@ -138,7 +138,7 @@ function SeqReadsReports({
       ))}
     </main>
   </>;
-}
+};
 
 export default SeqReadsReports;
 

--- a/src/views/sars2/report-by-reads/single-report.tsx
+++ b/src/views/sars2/report-by-reads/single-report.tsx
@@ -22,6 +22,7 @@ import {
 } from '../format-date';
 
 import style from '../style.module.scss';
+import {ObservePayload} from '../../../utils/use-scroll-observer';
 
 interface CoveragesInput {
   allReads: Array<{gene: string; position: number; totalReads: number}>;
@@ -59,15 +60,21 @@ interface SingleSeqReadsReportProps {
   /** Index of the sample. */
   index: number;
   /** Intersection observer callback. */
-  onObserve: (el: Element) => void;
+  onObserve: (payload: ObservePayload) => void;
   /** Intersection observer disconnect callback. */
-  onDisconnect: (el: Element) => void;
+  onDisconnect: (payload: ObservePayload) => void;
 }
 
 /**
  * Render a single sequence read analysis report.
  */
-function SingleSeqReadsReport({
+/**
+ * Render a single sequence read analysis report.
+ *
+ * @param props - {@link SingleSeqReadsReportProps} describing the report.
+ * @returns JSX element rendering read analysis details.
+ */
+const SingleSeqReadsReport: React.FC<SingleSeqReadsReportProps> = ({
   cmtVersion,
   antibodies,
   drdbLastUpdate,
@@ -78,7 +85,7 @@ function SingleSeqReadsReport({
   index,
   onObserve,
   onDisconnect
-}: SingleSeqReadsReportProps): JSX.Element {
+}: SingleSeqReadsReportProps): JSX.Element => {
 
   const {
     strain: {display: strain} = {},
@@ -158,8 +165,7 @@ function SingleSeqReadsReport({
       </> : null}
     </article>
   );
-
-}
+};
 
 export default React.memo(
   SingleSeqReadsReport,

--- a/src/views/sars2/report-by-sequences/index.tsx
+++ b/src/views/sars2/report-by-sequences/index.tsx
@@ -30,14 +30,14 @@ interface ReportBySequencesContainerProps {
 /**
  * Render sequence analysis reports for individual sequences.
  */
-function ReportBySequencesContainer({
+const ReportBySequencesContainer: React.FC<ReportBySequencesContainerProps> = ({
   config,
   lazyLoad,
   output,
   match,
   sequences,
   currentSelected
-}: ReportBySequencesContainerProps): JSX.Element {
+}: ReportBySequencesContainerProps): JSX.Element => {
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
     console.log(
@@ -48,32 +48,35 @@ function ReportBySequencesContainer({
 
   const client = useApolloClient({
     payload: sequences,
-    config
+    config: config as any
   });
   const onExtendVariables = useExtendVariables({
-    config,
+    config: config as Record<string, any>,
     match
   });
 
-  return <SeqAnalysisLayout
-   query={query}
-   client={client}
-   sequences={sequences}
-   currentSelected={currentSelected}
-   renderPartialResults={output !== 'printable'}
-   lazyLoad={lazyLoad}
-   extraParams="$drdbVersion: String!, $cmtVersion: String!"
-   onExtendVariables={onExtendVariables}>
-    {props => (
-      <SeqReports
-       cmtVersion={config?.cmtVersion}
-       output={output}
-       match={match}
-       {...props} />
-    )}
-  </SeqAnalysisLayout>;
-
-}
+  return (
+    <SeqAnalysisLayout
+      query={query}
+      client={client}
+      sequences={sequences}
+      currentSelected={currentSelected}
+      renderPartialResults={output !== 'printable'}
+      lazyLoad={lazyLoad}
+      extraParams="$drdbVersion: String!, $cmtVersion: String!"
+      onExtendVariables={onExtendVariables}
+    >
+      {(props) => (
+        <SeqReports
+          cmtVersion={config?.cmtVersion}
+          output={output}
+          match={match}
+          {...props}
+        />
+      )}
+    </SeqAnalysisLayout>
+  );
+};
 
 interface WrapperProps {
   router: any;

--- a/src/views/sars2/report-by-sequences/reports.tsx
+++ b/src/views/sars2/report-by-sequences/reports.tsx
@@ -35,13 +35,13 @@ interface SequenceReportsProps {
   currentSelected?: any;
   antibodies?: any[];
   sequenceAnalysis: any[];
-  fetchAnother: () => void;
+  fetchAnother: (name: string, updateCurrentSelected: boolean) => Promise<void>;
 }
 
 /**
  * Render sequence analysis reports with pagination.
  */
-function SequenceReports({
+const SequenceReports: React.FC<SequenceReportsProps> = ({
   output,
   antibodies = [],
   cmtVersion,
@@ -52,7 +52,7 @@ function SequenceReports({
   currentSelected,
   sequenceAnalysis,
   fetchAnother
-}: SequenceReportsProps): JSX.Element {
+}: SequenceReportsProps) => {
 
   const {
     onObserve,
@@ -104,7 +104,7 @@ function SequenceReports({
       ))}
     </main>
   </>;
-}
+};
 
 export default SequenceReports;
 

--- a/src/views/sars2/report-by-sequences/single-report.tsx
+++ b/src/views/sars2/report-by-sequences/single-report.tsx
@@ -9,6 +9,7 @@ import {
   RefsSection,
   RefContextWrapper
 } from '../../../components/report';
+import {ObservePayload} from '../../../utils/use-scroll-observer';
 
 import SARS2MutComments from '../../../components/sars2-mutation-comments';
 import {
@@ -32,14 +33,17 @@ interface SingleSequenceReportProps {
   sequenceResult?: any;
   output: string;
   index: number;
-  onObserve: (el: Element) => void;
-  onDisconnect?: (el: Element) => void;
+  onObserve: (payload: ObservePayload) => void;
+  onDisconnect?: (payload: ObservePayload) => void;
 }
 
 /**
  * Render a single uploaded sequence analysis report.
+ *
+ * @param props - {@link SingleSequenceReportProps} describing the report.
+ * @returns JSX element of the sequence report.
  */
-function SingleSequenceReport({
+const SingleSequenceReport: React.FC<SingleSequenceReportProps> = ({
   cmtVersion,
   drdbLastUpdate,
   antibodies,
@@ -49,7 +53,7 @@ function SingleSequenceReport({
   index,
   onObserve,
   onDisconnect
-}: SingleSequenceReportProps): JSX.Element {
+}: SingleSequenceReportProps): JSX.Element => {
 
   const {
     alignedGeneSequences,
@@ -119,8 +123,7 @@ function SingleSequenceReport({
       </RefContextWrapper>
     </article>
   );
-
-}
+};
 
 export default React.memo(
   SingleSequenceReport,

--- a/src/views/sars2/tabular-report-by-reads/index.tsx
+++ b/src/views/sars2/tabular-report-by-reads/index.tsx
@@ -40,7 +40,7 @@ export default function TabularReportByReadsContainer({
   const [config, isConfigPending] = ConfigContext.use();
 
   const handleExtendVariables = useExtendVariables({
-    config,
+    config: config as Record<string, any>,
     match
   });
 
@@ -51,7 +51,7 @@ export default function TabularReportByReadsContainer({
   });
 
   const client = useApolloClient({
-    config,
+    config: config as Record<string, any>,
     skip: isConfigPending || isPending,
     payload: allSeqReadsWithParams
   });
@@ -61,28 +61,35 @@ export default function TabularReportByReadsContainer({
     [children]
   );
 
-  if (isConfigPending || isPending) {
+  if (isConfigPending || isPending || !config || !allSeqReadsWithParams) {
     return null;
   }
 
-  return <SeqReadsAnalysisLayout
-   query={getQuery(curSubOptions)}
-   client={client}
-   allSequenceReads={allSeqReadsWithParams}
-   currentSelected={{index: 0}}
-   renderPartialResults={false}
-   lazyLoad={false}
-   extraParams={getExtraParams(curSubOptions)}
-   onExtendVariables={handleExtendVariables}>
-    {props => (
-      <SeqTabularReports
-       config={config}
-       children={children}
-       onFinish={onFinish}
-       patternsTo={patternsTo}
-       {...props} />
-    )}
-  </SeqReadsAnalysisLayout>;
+  const firstReadsName =
+    allSeqReadsWithParams[0]?.name || 'Reads 1';
+
+  return (
+    <SeqReadsAnalysisLayout
+      query={getQuery(curSubOptions)}
+      client={client}
+      allSequenceReads={allSeqReadsWithParams as any[]}
+      currentSelected={{index: 0, name: firstReadsName}}
+      renderPartialResults={false}
+      lazyLoad={false}
+      extraParams={getExtraParams(curSubOptions)}
+      onExtendVariables={handleExtendVariables}
+    >
+      {(props) => (
+        <SeqTabularReports
+          config={config}
+          children={children}
+          onFinish={onFinish}
+          patternsTo={patternsTo}
+          {...props}
+        />
+      )}
+    </SeqReadsAnalysisLayout>
+  );
 
 }
 

--- a/src/views/sars2/tabular-report-by-reads/sub-options.ts
+++ b/src/views/sars2/tabular-report-by-reads/sub-options.ts
@@ -3,13 +3,14 @@ import suscSummary from '../tabular-report/sars2-susc-summary';
 import mutComments from '../tabular-report/sars2-mutation-comments';
 import unseqRegions from '../../../components/tabular-report/unseq-regions';
 import mutationList from '../../../components/tabular-report/mutation-list';
-import assembledConsensus
-  from '../../../components/tabular-report/assembled-consensus';
-import prettyAlignments
-  from '../../../components/tabular-report/pretty-alignments';
-import rawJSON
-  from '../../../components/tabular-report/raw-json';
+import assembledConsensus from '../../../components/tabular-report/assembled-consensus';
+import prettyAlignments from '../../../components/tabular-report/pretty-alignments';
+import rawJSON from '../../../components/tabular-report/raw-json';
+import {TabularReportProcessor} from '../../../components/tabular-report/reports';
 
+/**
+ * Display titles for available tabular report sub-options.
+ */
 const subOptions = [
   'Sequence summary',
   'Consensus sequence (FASTA)',
@@ -21,15 +22,18 @@ const subOptions = [
   'Raw JSON report'
 ];
 
-const subOptionProcessors = [
-  seqReadsSummary,
-  assembledConsensus,
-  mutationList,
-  unseqRegions,
-  suscSummary,
-  mutComments,
-  prettyAlignments,
-  rawJSON
+/**
+ * Processor functions generating sub-option reports.
+ */
+const subOptionProcessors: TabularReportProcessor[] = [
+  seqReadsSummary as TabularReportProcessor,
+  assembledConsensus as TabularReportProcessor,
+  mutationList as TabularReportProcessor,
+  unseqRegions as TabularReportProcessor,
+  suscSummary as TabularReportProcessor,
+  mutComments as TabularReportProcessor,
+  prettyAlignments as TabularReportProcessor,
+  rawJSON as TabularReportProcessor
 ];
 
 export {subOptions, subOptionProcessors};

--- a/src/views/sars2/tabular-report-by-sequences/index.tsx
+++ b/src/views/sars2/tabular-report-by-sequences/index.tsx
@@ -14,14 +14,25 @@ import {subOptions} from './sub-options';
 export {subOptions};
 
 interface TabularReportBySequencesContainerProps {
+  /** indices of selected report sub-options */
   subOptionIndices: number[];
-  sequences: any[];
+  /** sequences to be analysed */
+  sequences: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
+  /** callback triggered when report generation finishes */
   onFinish: () => void;
+  /** prefix used when linking patterns in the report */
   patternsTo: string;
 }
 
 /**
  * Render tabular reports for uploaded sequences.
+ *
+ * @param subOptionIndices - indices of selected report types.
+ * @param sequences - sequences to analyse.
+ * @param onFinish - callback triggered when processing completes.
+ * @param patternsTo - prefix for pattern links inside the reports.
+ * @returns JSX layout wrapping {@link SequenceAnalysisLayout} or `null` when
+ * the configuration is still pending.
  */
 export default function TabularReportBySequencesContainer({
   subOptionIndices,
@@ -33,13 +44,13 @@ export default function TabularReportBySequencesContainer({
   const {match} = useRouter();
   const [config, isConfigPending] = ConfigContext.use();
   const client = useApolloClient({
-    config,
+    config: config as any,
     skip: isConfigPending,
     payload: sequences
   });
 
   const handleExtendVariables = useExtendVariables({
-    config,
+    config: config as Record<string, any>,
     match
   });
 
@@ -48,28 +59,37 @@ export default function TabularReportBySequencesContainer({
     [subOptionIndices]
   );
 
-  if (isConfigPending) {
+  if (isConfigPending || !config) {
     return null;
   }
 
-  return <SequenceAnalysisLayout
-   query={getQuery(curSubOptions)}
-   client={client}
-   sequences={sequences}
-   currentSelected={{index: 0}}
-   renderPartialResults={false}
-   lazyLoad={false}
-   extraParams={getExtraParams(curSubOptions)}
-   onExtendVariables={handleExtendVariables}>
-    {props => (
-      <SeqTabularReports
-       config={config}
-       subOptionIndices={subOptionIndices}
-       onFinish={onFinish}
-       patternsTo={patternsTo}
-       {...props} />
-    )}
-  </SequenceAnalysisLayout>;
+  const firstSeqName =
+    sequences[0]?.name ||
+    sequences[0]?.inputSequence?.header ||
+    'Sequence 1';
+
+  return (
+    <SequenceAnalysisLayout
+      query={getQuery(curSubOptions)}
+      client={client}
+      sequences={sequences}
+      currentSelected={{index: 0, name: firstSeqName}}
+      renderPartialResults={false}
+      lazyLoad={false}
+      extraParams={getExtraParams(curSubOptions)}
+      onExtendVariables={handleExtendVariables}
+    >
+      {(props) => (
+        <SeqTabularReports
+          config={config}
+          subOptionIndices={subOptionIndices}
+          onFinish={onFinish}
+          patternsTo={patternsTo}
+          {...props}
+        />
+      )}
+    </SequenceAnalysisLayout>
+  );
 
 }
 

--- a/src/views/sars2/tabular-report-by-sequences/sub-options.ts
+++ b/src/views/sars2/tabular-report-by-sequences/sub-options.ts
@@ -3,11 +3,13 @@ import suscSummary from '../tabular-report/sars2-susc-summary';
 import mutComments from '../tabular-report/sars2-mutation-comments';
 import unseqRegions from '../../../components/tabular-report/unseq-regions';
 import mutationList from '../../../components/tabular-report/mutation-list';
-import prettyAlignments
-  from '../../../components/tabular-report/pretty-alignments';
-import rawJSON
-  from '../../../components/tabular-report/raw-json';
+import prettyAlignments from '../../../components/tabular-report/pretty-alignments';
+import rawJSON from '../../../components/tabular-report/raw-json';
+import {TabularReportProcessor} from '../../../components/tabular-report/reports';
 
+/**
+ * List of available tabular report sub-options in display order.
+ */
 const subOptions = [
   'Sequence summary',
   'Mutation list',
@@ -18,14 +20,17 @@ const subOptions = [
   'Raw JSON report'
 ];
 
-const subOptionProcessors = [
-  seqSummary,
-  mutationList,
-  unseqRegions,
-  suscSummary,
-  mutComments,
-  prettyAlignments,
-  rawJSON
+/**
+ * Processor functions corresponding to {@link subOptions}.
+ */
+const subOptionProcessors: TabularReportProcessor[] = [
+  seqSummary as TabularReportProcessor,
+  mutationList as TabularReportProcessor,
+  unseqRegions as TabularReportProcessor,
+  suscSummary as TabularReportProcessor,
+  mutComments as TabularReportProcessor,
+  prettyAlignments as TabularReportProcessor,
+  rawJSON as TabularReportProcessor
 ];
 
 export {subOptions, subOptionProcessors};

--- a/src/views/sars2/tabular-report/sars2-susc-summary/antibodies.ts
+++ b/src/views/sars2/tabular-report/sars2-susc-summary/antibodies.ts
@@ -1,10 +1,13 @@
 import nestedGet from 'lodash/get';
-import {
-  getAntibodyColumns,
-  buildPayload
-} from '../../../../components/susc-summary/ab-susc-summary';
+import {getAntibodyColumns, buildPayload} from '../../../../components/susc-summary/ab-susc-summary';
 
-function extractFold(item: any) {
+/**
+ * Format fold values for display.
+ *
+ * @param item - fold object from DRDB.
+ * @returns Formatted fold string or `null` when missing.
+ */
+function extractFold(item: any): string | null {
   if (!item) {
     return null;
   }
@@ -14,23 +17,44 @@ function extractFold(item: any) {
   return median >= 1000 ? '≥1000' : `${median.toFixed(1)}`;
 }
 
-function extractCumuCount(item: any) {
+/**
+ * Extract cumulative count from a fold entry.
+ *
+ * @param item - fold object from DRDB.
+ * @returns Cumulative count or `null` when unavailable.
+ */
+function extractCumuCount(item: any): number | null {
   if (!item) {
     return null;
   }
   return item.cumulativeCount;
 }
 
-function joinMutations(mutations: any[]) {
+/**
+ * Join mutation texts with commas.
+ *
+ * @param mutations - list of mutation objects.
+ * @returns Joined mutation string or 'None' when empty.
+ */
+function joinMutations(mutations: any[]): string {
   return mutations.map(({text}) => text).join(', ') || 'None';
 }
 
+/**
+ * Build antibody susceptibility table rows.
+ *
+ * @param seqName - sequence name.
+ * @param itemsByVariantOrMutations - grouped susceptibility items.
+ * @param drdbLastUpdate - DRDB version string.
+ * @param antibodyColumns - antibodies used to generate columns.
+ * @returns Array of row objects for CSV generation.
+ */
 function buildAbTable({
   seqName,
   itemsByVariantOrMutations,
   drdbLastUpdate,
   antibodyColumns
-}: any) {
+}: any): any[] {
   const rows: any[] = [];
   for (const {
     mutations,
@@ -47,9 +71,9 @@ function buildAbTable({
       'Mutations': joinMutations(mutations),
       'Variant': variant ? variant.name : 'NA',
       'Additional Mutations':
-        variant ? joinMutations(variantMissingMutations) : 'NA',
+        variant ? joinMutations(variantMissingMutations ?? []) : 'NA',
       'Missing Mutations':
-        variant ? joinMutations(variantExtraMutations) : 'NA',
+        variant ? joinMutations(variantExtraMutations ?? []) : 'NA',
       'References': references.map(({DOI, URL}: any) => DOI || URL).join(' ; '),
       'Version': drdbLastUpdate,
       'Top Match': displayOrder === 0 ? 'Yes' : 'No'
@@ -69,6 +93,15 @@ function buildAbTable({
   return rows;
 }
 
+/**
+ * Generate antibody susceptibility summary tables.
+ *
+ * @param drdbLastUpdate - DRDB version string.
+ * @param antibodies - antibody definitions.
+ * @param sequenceReadsAnalysis - analysis results from reads.
+ * @param sequenceAnalysis - analysis results from sequences.
+ * @returns Array of tabular report objects for antibodies.
+ */
 export default function abSuscSummary({
   drdbLastUpdate,
   antibodies,


### PR DESCRIPTION
## Summary
- expand tabular report sequence handler with safer config usage and naming
- type tabular report sub-option processors and refine antibody summary helpers
- consolidate scroll observer payload typing across report components

## Testing
- `yarn test --no-file-parallelism` *(fails: some components still reference Element instead of ObservePayload and missing config details during build)*

------
https://chatgpt.com/codex/tasks/task_e_6896a953328c8324ad85f34ad803c047