### PR TITLE
fix: improve type safety for utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,10 @@
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/prop-types": "^15.7.11",
     "@types/react": "19.1.9",
     "@types/react-dom": "19.1.7",
+    "@types/uuid": "^9.0.7",
     "@vitejs/plugin-react": "4.7.0",
     "@vx/axis": "^0.0.199",
     "@vx/bounds": "^0.0.199",
@@ -98,11 +100,10 @@
     "web-vitals": "^2.1.4",
     "xlsx": "^0.18.5",
     "xmlbuilder2": "^3.0.2",
-    "youtube-url": "^0.5.0",
-    "@types/uuid": "^9.0.7",
-    "@types/prop-types": "^15.7.11"
+    "youtube-url": "^0.5.0"
   },
   "devDependencies": {
+    "@types/pako": "^2.0.3",
     "jsdom": "26.1.0",
     "sass-embedded": "^1.89.2",
     "vitest": "3.2.4"

--- a/src/utils/download.ts
+++ b/src/utils/download.ts
@@ -2,6 +2,17 @@ import React from 'react';
 import JSZip from 'jszip';
 import useMounted from './use-mounted';
 
+declare global {
+  interface Window {
+    showSaveFilePicker?: (options?: any) => Promise<any>;
+    showDirectoryPicker?: (options?: any) => Promise<any>;
+  }
+
+  interface Navigator {
+    msSaveOrOpenBlob?: (blob: Blob, fileName: string) => void;
+  }
+}
+
 /**
  * Show a file picker dialog when supported by the browser.
  *
@@ -65,6 +76,9 @@ const utf8Encoder = new TextEncoder();
  * @param data - Blob or string content to download.
  * @param isBlob - When `true`, `data` is already a `Blob` instance.
  * @param fileHandle - Optional file handle obtained from picker.
+ *
+ * Writes the data using the File System Access API when a handle is
+ * provided, falling back to a hidden anchor element when not available.
  */
 export async function makeDownload(
   fileName: string,
@@ -124,6 +138,12 @@ export async function makeDownload(
   }
 }
 
+/**
+ * Create an object URL and trigger a download via an anchor element.
+ *
+ * @param fileName - Name to assign to the downloaded file.
+ * @param data - Blob representing the file contents.
+ */
 function fallbackDownload(fileName: string, data: Blob): void {
   const ts = new Date().getTime();
   fileName = fileName.replace(/(\.[^.]+$|$)/, `_${ts}$1`);
@@ -146,16 +166,29 @@ function fallbackDownload(fileName: string, data: Blob): void {
   }
 }
 
+/**
+ * Write a blob to a handle obtained from the File System Access API.
+ *
+ * @param fileHandle - Handle representing the destination file.
+ * @param data - Blob to persist.
+ */
 async function writeToFileHandle(fileHandle: any, data: Blob): Promise<void> {
   const writeFS = await fileHandle.createWritable();
   await writeFS.write(data);
   await writeFS.close();
 }
 
+/**
+ * Sanitize a filename by replacing characters that are invalid on most
+ * filesystems.
+ */
 function cleanFileName(name: string): string {
   return name.replace(/[\\/:*?"<>|]/g, '.');
 }
 
+/**
+ * Create the mutable state object used by {@link useDownload}.
+ */
 function defaultState() {
   return {
     initiated: false,
@@ -178,11 +211,13 @@ interface UseDownloadArgs {
  * the File System Access API.
  *
  * @param args - Configuration for the download behaviour.
- * @returns Helper methods and state describing the download process.
+ * @returns Helper methods and state describing the download process. The
+ * `isDownloading` flag in the return value indicates whether the process is
+ * currently active.
  */
 export function useDownload({name, suffix, types, multiple = true}: UseDownloadArgs) {
   const isMounted = useMounted();
-  const [isDownloading, setIsDownloading] = React.useState(false);
+  const [isDownloading, setIsDownloading] = React.useState<number | boolean>(false);
   const state = React.useRef(defaultState());
 
   const onInit = React.useCallback(
@@ -239,9 +274,13 @@ export function useDownload({name, suffix, types, multiple = true}: UseDownloadA
       if (folder && /[/\\]$/.test(folder)) {
         throw new Error('folder must not end with slash (/) or backslash (\\)');
       }
+      let blobData: Blob;
       if (!isBlob) {
-        data = utf8Encoder.encode(data);
-        data = new Blob([data]);
+        const encoded = utf8Encoder.encode(data as string);
+        blobData = new Blob([encoded]);
+      }
+      else {
+        blobData = data as Blob;
       }
       if (dirHandle !== null) {
         // multiple files save in directory
@@ -252,20 +291,20 @@ export function useDownload({name, suffix, types, multiple = true}: UseDownloadA
           }
         }
         const fileH = await dirH.getFileHandle(fileName, {create: true});
-        await writeToFileHandle(fileH, data);
+        await writeToFileHandle(fileH, blobData);
       }
       else if (zipObj !== null) {
         // multiple files save in ZIP
         const filePath = folder ? `${folder}/${fileName}` : fileName;
-        zipObj.folder(name).file(filePath, data);
+        zipObj.folder(name).file(filePath, blobData);
       }
       else if (fileHandle !== null) {
         // single file save to fileHandle
-        await writeToFileHandle(fileHandle, data);
+        await writeToFileHandle(fileHandle, blobData);
       }
       else {
         // single file download fallback
-        fallbackDownload(fileName || (name + suffix), data);
+        fallbackDownload(fileName || (name + suffix), blobData);
       }
       state.current.loadedFiles.push(
         folder ? `${folder}/${fileName}` : fileName

--- a/src/utils/nl2br.tsx
+++ b/src/utils/nl2br.tsx
@@ -3,18 +3,21 @@ import React from 'react';
 const newLineRegex = /(\r\n|\n\r|\r|\n)/g;
 
 /**
- * Convert newline characters to `<br/>` elements.
+ * Convert newline characters in a string into React elements.
+ *
+ * Each newline sequence is replaced with a `<br/>` element so that the
+ * resulting array can be rendered directly within JSX without additional
+ * processing.
  *
  * @param text - Text containing newline characters.
- * @returns Array of strings and `<br/>` elements.
+ * @returns Array of strings and `<br/>` elements representing the original
+ * newline boundaries.
  */
-export default function nl2br(text: string): Array<string | JSX.Element> {
+export default function nl2br(text: string): React.ReactNode[] {
   return text.split(newLineRegex).map((line, idx) => {
     if (newLineRegex.test(line)) {
       return <br key={idx} />;
     }
-    else {
-      return line;
-    }
+    return line;
   });
 }

--- a/src/utils/promise-component.tsx
+++ b/src/utils/promise-component.tsx
@@ -44,6 +44,8 @@ export interface PromiseComponentProps<T = unknown, P = any> {
  * (defaulting to {@link Loader}).  Once the promise settles, the resolved
  * value is passed through `then` or `error` and rendered either directly or
  * via the optional `component` prop.
+ *
+ * @returns A React element representing the resolved content.
  */
 export default function PromiseComponent<T = unknown, P = any>({
   promise,
@@ -51,7 +53,7 @@ export default function PromiseComponent<T = unknown, P = any>({
   error = (err: unknown) => err as React.ReactNode,
   component,
   children = <Loader />
-}: PromiseComponentProps<T, P>): JSX.Element {
+}: PromiseComponentProps<T, P>): React.ReactElement {
   const [childProps, setChildProps] = React.useState<P | null>(null);
   const [rendered, setRendered] = React.useState<React.ReactNode>(children);
   const loadedRef = React.useRef<Promise<T> | T | false>(false);
@@ -119,11 +121,13 @@ export interface AsyncComponentProps {
 /**
  * Convenience wrapper around {@link PromiseComponent} which resolves after a
  * specified timeout and then renders its children.
+ *
+ * @returns A React element that appears once the delay has elapsed.
  */
 export function AsyncComponent({
   children,
   duration = 0
-}: AsyncComponentProps): JSX.Element {
+}: AsyncComponentProps): React.ReactElement {
   const thenRender = React.useCallback(() => children(), [children]);
   const promise = React.useMemo(() => sleep(duration), [duration]);
   return <PromiseComponent promise={promise} then={thenRender} />;

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/config-generator.ts
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/config-generator.ts
@@ -1,4 +1,5 @@
 import {getColorHex} from '../../../../utils/colors';
+import type {LegendContextValue} from '../legend-context';
 
 import type {SeqViewerSize} from '../../prop-types';
 
@@ -413,7 +414,7 @@ export default class ConfigGenerator {
     return {x, y};
   };
 
-  coord2UnderscoreAnnot = (x, y) => {
+  coord2UnderscoreAnnot = (x: number, y: number): {annotName?: string; x?: number; y?: number} => {
     const {
       posItemSizePixel,
       underscoreAnnotHeightPixel,
@@ -438,7 +439,7 @@ export default class ConfigGenerator {
     return {};
   };
 
-  coord2Pos = (x, y) => {
+  coord2Pos = (x: number, y: number): number | null => {
     const {
       canvasWidthPixel: canvasWidth,
       canvasHeightPixel: canvasHeight,
@@ -486,8 +487,8 @@ export default class ConfigGenerator {
     return pos;
   };
 
-  getAnnotPosLookup(annotStyle) {
-    let lookup;
+  getAnnotPosLookup(annotStyle: string): Record<number, unknown> {
+    let lookup: Record<number, unknown>;
     switch (annotStyle) {
       case 'colorBox':
         lookup = this.colorBoxPositions;
@@ -501,8 +502,8 @@ export default class ConfigGenerator {
     return lookup;
   }
 
-  getAnnotatedAAs = (pos) => {
-    const aaDefs = [];
+  getAnnotatedAAs = (pos: number) => {
+    const aaDefs: Array<{aminoAcid: string; offsetPixel: {x: number; y: number}; color: string}> = [];
     let globalIdxOffset = 0;
     const {aminoAcidsOverrideColors} = this;
     for (const lookup of this.aminoAcidsAnnotPositions) {
@@ -527,12 +528,12 @@ export default class ConfigGenerator {
     return aaDefs;
   };
 
-  isPositionAnnotated = (pos, annotStyle) => {
+  isPositionAnnotated = (pos: number, annotStyle: string): boolean => {
     const lookup = this.getAnnotPosLookup(annotStyle);
     return pos in lookup;
   };
 
-  getColorIndex = (pos, annotStyle) => {
+  getColorIndex = (pos: number, annotStyle: string): number | undefined => {
     const lookup = this.getAnnotPosLookup(annotStyle);
     const posDef = lookup[pos];
     if (posDef) {
@@ -541,7 +542,7 @@ export default class ConfigGenerator {
     }
   };
 
-  getUnderscoreAnnotColorIndex = (annotName) => {
+  getUnderscoreAnnotColorIndex = (annotName: string): number => {
     const {underscoreAnnotColorIndexOffset, underscoreAnnotNames} = this;
     const colorIdx = (
       underscoreAnnotNames.indexOf(annotName) +
@@ -550,7 +551,7 @@ export default class ConfigGenerator {
     return colorIdx;
   };
 
-  getStrokeColor = (pos, hovering, annotStyle) => {
+  getStrokeColor = (pos: number, hovering: boolean, annotStyle: string): string => {
     if (hovering) {
       return this.strokeDefaultColorHovering;
     }
@@ -563,7 +564,12 @@ export default class ConfigGenerator {
     }
   };
 
-  getRefAAColor = (pos) => {
+  /**
+   * Get reference amino acid color for a given position.
+   * @param pos - Sequence position.
+   * @returns Hex color string.
+   */
+  getRefAAColor = (pos: number): string => {
     if (
       !this.isPositionAnnotated(pos, 'colorBox') &&
       this.isPositionAnnotated(pos, 'circleInBox')
@@ -573,7 +579,14 @@ export default class ConfigGenerator {
     return this.refAADarkColor;
   };
 
-  getBgColor = (pos, hovering, annotStyle) => {
+  /**
+   * Resolve background color for a position.
+   *
+   * @param pos - Sequence position.
+   * @param hovering - Whether the position is currently hovered.
+   * @param annotStyle - Annotation style to consider.
+   */
+  getBgColor = (pos: number, hovering: boolean, annotStyle: string): string => {
     if (hovering) {
       return this.backgroundDefaultColorHovering;
     }
@@ -592,25 +605,36 @@ export default class ConfigGenerator {
     }
   };
 
-  getUnderscoreAnnotColor = (annotName) => {
+  /**
+   * Get color for underscore annotations.
+   *
+   * @param annotName - Annotation identifier.
+   */
+  getUnderscoreAnnotColor = (annotName: string): string => {
     const colorIdx = this.getUnderscoreAnnotColorIndex(annotName);
     return getColorHex(colorIdx, 'med');
   };
 
-  updateLegendContext = ({onUpdate}) => {
+  /**
+   * Update legend context with calculated color lookups.
+   * @param onUpdate - Callback to merge legend colors.
+   */
+  updateLegendContext = ({onUpdate}: {onUpdate: (opts: Partial<Omit<LegendContextValue, 'onUpdate'>>) => void}): void => {
     const {aminoAcidsOverrideColors} = this;
-    const colorBoxAnnotColorIdx = {};
-    for (const [, colorIdx, val] of Object.values(this.colorBoxPositions)) {
-      colorBoxAnnotColorIdx[val] = colorIdx;
-    }
-    const colorBoxAnnotColorLookup = {};
-    for (let [val, colorIdx] of Object.entries(colorBoxAnnotColorIdx)) {
+    const colorBoxAnnotColorIdx: Record<string, number> = {};
+      for (const [, colorIdx, val] of Object.values(
+        this.colorBoxPositions as Record<number, [number, number, string]>
+      ) as [number, number, string][]) {
+        colorBoxAnnotColorIdx[val] = colorIdx;
+      }
+    const colorBoxAnnotColorLookup: Record<string, {stroke: string; bg: string}> = {};
+    for (const [val, colorIdx] of Object.entries(colorBoxAnnotColorIdx)) {
       colorBoxAnnotColorLookup[val] = {
         stroke: getColorHex(colorIdx, 'dark'),
         bg: getColorHex(colorIdx, 'light')
       };
     }
-    const underscoreAnnotColorLookup = {};
+    const underscoreAnnotColorLookup: Record<string, string> = {};
     for (const annotName of this.underscoreAnnotNames) {
       underscoreAnnotColorLookup[annotName] = (
         this.getUnderscoreAnnotColor(annotName)
@@ -619,8 +643,8 @@ export default class ConfigGenerator {
     onUpdate({
       colorBoxAnnotColorLookup,
       underscoreAnnotColorLookup,
-      aminoAcidsCatColorLookup: this.aminoAcidsCatNames
-        .reduce((acc, name, idx) => {
+      aminoAcidsCatColorLookup: (this.aminoAcidsCatNames as string[])
+        .reduce<Record<string, string>>((acc, name, idx) => {
           acc[name] = (
             aminoAcidsOverrideColors[idx] ||
             getColorHex(idx, 'dark')

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/funcs.ts
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/funcs.ts
@@ -273,7 +273,7 @@ export function calcUnderscoreAnnotLocations(
     let maxAvailableLoc = 0;
     for (let pos0 = posStart - 1; pos0 < posEnd; pos0 ++) {
       matrix[pos0] = matrix[pos0] || [];
-      for (const idx in matrix[pos0]) {
+      for (let idx = 0; idx < matrix[pos0].length; idx ++) {
         if (matrix[pos0][idx]) {
           usedLocs[idx] = true;
         }

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/index.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/index.tsx
@@ -64,6 +64,10 @@ export default function HoverLayer({
       <PositionGroup position={pos} config={config} key={pos} />
     ))}
     {hoverUSAnnot.annotName ?
-      <USAnnotGroup {...hoverUSAnnot} config={config} /> : null}
+      <USAnnotGroup
+       annotName={hoverUSAnnot.annotName!}
+       x={hoverUSAnnot.x!}
+       y={hoverUSAnnot.y!}
+       config={config} /> : null}
   </Layer>;
 }

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/position-group.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/position-group.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Group, Rect, Text} from 'react-konva';
+import type {Text as KonvaText} from 'konva/lib/shapes/Text';
 
 interface HoverPositionGroupProps {
   position: number;
@@ -33,12 +34,12 @@ export default function PositionGroup({
   }
 }: HoverPositionGroupProps) {
 
-  const posNumTextRef = React.useRef<Text>(null);
+  const posNumTextRef = React.useRef<KonvaText>(null);
   const [addOffsetX, setAddOffsetX] = React.useState(0);
 
   React.useEffect(
     () => setAddOffsetX(
-      (posItemSizePixel - posNumTextRef.current!.getWidth()) / 2
+      (posItemSizePixel - (posNumTextRef.current?.getWidth() ?? 0)) / 2
     ),
     [posItemSizePixel]
   );
@@ -71,7 +72,7 @@ export default function PositionGroup({
        fontFamily={fontFamily}
        fill={hoverTextColor}
        align="center"
-       text={position} />
+       text={position.toString()} />
       <Text
        ref={posNumTextRef}
        x={posNumOffset.x}
@@ -81,7 +82,7 @@ export default function PositionGroup({
        fontFamily={fontFamily}
        fill={hoverTextColor}
        align="center"
-       text={position} />
+       text={position.toString()} />
     </Group>
   );
 }

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/underscore-annot-group.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/hover-layer/underscore-annot-group.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {Group, Text} from 'react-konva';
+import type {Text as KonvaText} from 'konva/lib/shapes/Text';
 
 interface UnderscoreAnnotGroupProps {
   annotName: string;
@@ -32,12 +33,12 @@ export default function UnderscoreAnnotGroup({
     fontFamily
   }
 }: UnderscoreAnnotGroupProps) {
-  const textRef = React.useRef<Text>(null);
+  const textRef = React.useRef<KonvaText>(null);
   const [currentWidth, setCurrentWidth] = React.useState(posItemSizePixel);
 
   React.useEffect(
-    () => setCurrentWidth(textRef.current!.getWidth()),
-    []
+    () => setCurrentWidth(textRef.current?.getWidth() ?? posItemSizePixel),
+    [posItemSizePixel]
   );
 
   const textOffset = React.useMemo(

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/index.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/index.tsx
@@ -12,7 +12,7 @@ import {
   calcUnderscoreAnnotLocations
 } from './funcs';
 
-import LegendContext from '../legend-context';
+import LegendContext, {type LegendContextValue} from '../legend-context';
 
 import type {
   CurAnnotNameLookup,
@@ -26,7 +26,7 @@ import type {
 /**
  * Hook providing a ref to the container element and tracking its width.
  */
-function useContainer(): [React.RefObject<HTMLDivElement>, number | null] {
+function useContainer(): [React.RefObject<HTMLDivElement | null>, number | null] {
   const containerRef = React.useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = React.useState<number | null>(null);
 
@@ -81,21 +81,24 @@ function useConfig({
   curAnnotNameLookup: CurAnnotNameLookup;
   annotCategories: AnnotCategory[];
   containerWidth: number | null;
-  legendContext: {onUpdate: (val: unknown) => void};
+  legendContext: LegendContextValue;
 }) {
   const config = React.useMemo(
-    () => {
-      let colorBoxPositions = [];
-      let circleInBoxPositions = [];
-      let underscoreAnnotLocations = [];
-      let underscoreAnnotNames = [];
-      const aminoAcidsAnnotPositions = [];
-      const aminoAcidsCatNames = [];
-      const aminoAcidsOverrideColors = [];
+      () => {
+        let colorBoxPositions: Record<number, unknown> = {};
+        let circleInBoxPositions: Record<number, unknown> = {};
+        let underscoreAnnotLocations: {locations: any[]; matrix: any[]} = {
+          locations: [],
+          matrix: []
+        };
+        let underscoreAnnotNames: string[] = [];
+        const aminoAcidsAnnotPositions: Record<number, unknown>[] = [];
+        const aminoAcidsCatNames: string[] = [];
+        const aminoAcidsOverrideColors: string[] = [];
       let aaAnnotIdx = 0;
       for (const cat of annotCategories) {
         const {name: catName, annotStyle} = cat;
-        const curAnnotNames = curAnnotNameLookup[catName] || [];
+        const curAnnotNames: string[] = curAnnotNameLookup[catName] || [];
         const curAnnots = annotations.filter(
           ({name}) => curAnnotNames.includes(name)
         );
@@ -121,7 +124,7 @@ function useConfig({
               aaAnnotIdx ++
             );
             aminoAcidsCatNames.push(catName);
-            aminoAcidsOverrideColors.push(cat.color);
+              aminoAcidsOverrideColors.push(cat.color ?? '');
             break;
           default:
             break;
@@ -133,10 +136,9 @@ function useConfig({
           sizeName: size,
           seqFragment,
           canvasWidthPixel: containerWidth,
-          seqLength: sequence.length,
-          colorBoxPositions,
-          circleInBoxPositions,
-          underscoreAnnotLocations,
+            colorBoxPositions,
+            circleInBoxPositions,
+            underscoreAnnotLocations,
           underscoreAnnotNames,
           aminoAcidsAnnotPositions,
           aminoAcidsCatNames,
@@ -161,9 +163,9 @@ function useConfig({
   React.useEffect(
     () => {
       const update = config?.updateLegendContext;
-      if (update) {
-        update({onUpdate});
-      }
+        if (update) {
+          update({onUpdate: onUpdate as any});
+        }
     },
     [config?.updateLegendContext, onUpdate]
   );

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/positem-layer/index.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/positem-layer/index.tsx
@@ -32,7 +32,6 @@ export default function PosItemLayer({
         <PositionGroup
          key={pos0}
          config={config}
-         posAnnot={positionLookup[pos0 + posStart]}
          position={pos0 + posStart}
          residue={residue} />
       ))}

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/positem-layer/position-group.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/positem-layer/position-group.tsx
@@ -98,7 +98,7 @@ export default function PositionGroup({
      fill={posNumColor}
      fontFamily={fontFamily}
      fontSize={posNumFontSizePixel}
-     text={position} />
+     text={position.toString()} />
     <Text
      x={refAAOffset.x}
      y={refAAOffset.y}

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/stage.tsx
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/stage.tsx
@@ -153,7 +153,7 @@ function useKeyboard({
   selection: {activePos, anchorPos, prevSelecteds},
   setSelection
 }: {
-  containerRef: React.RefObject<HTMLDivElement>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
   selectedPositions: number[];
@@ -216,16 +216,17 @@ function useKeyboard({
   );
 
   const handleKeyDown = React.useCallback(
-    (evt: React.KeyboardEvent) => {
+    (evt: KeyboardEvent) => {
       const {key, shiftKey: rangeSel} = evt;
       const {
         numCols, numPosPerPage,
         seqFragment: [absPosStart, absPosEnd]
       } = config;
-      let posEnd = activePos;
-      if (posEnd == null) {
+      const posEndNum = activePos;
+      if (posEndNum == null) {
         return;
       }
+      let posEnd = posEndNum;
       switch (key) {
         case 'ArrowLeft':
           posEnd --;
@@ -262,21 +263,21 @@ function useKeyboard({
       }
       evt.preventDefault();
       evt.stopPropagation();
-      if (posEnd < absPosStart || posEnd > absPosEnd) {
-        return;
-      }
-      const newSel: Partial<SelectionState> = {
-        activePos: posEnd,
-        anchorPos
-      };
+        if (posEnd < absPosStart || posEnd > absPosEnd) {
+          return;
+        }
+        const newSel: Partial<SelectionState> = {
+          activePos: posEnd,
+          anchorPos
+        };
       if (!rangeSel) {
         newSel.anchorPos = posEnd;
       }
-      setSelection(newSel);
-      handleKeySelection(rangeSel, newSel);
-    },
-    [config, handleKeySelection, setSelection, activePos, anchorPos]
-  );
+        setSelection(newSel);
+        handleKeySelection(rangeSel, {anchorPos: newSel.anchorPos!, activePos: newSel.activePos!});
+      },
+      [config, handleKeySelection, setSelection, activePos, anchorPos]
+    );
 
   const handleGlobalKeyDown = React.useCallback(
     (evt: KeyboardEvent) => {
@@ -285,7 +286,7 @@ function useKeyboard({
         seqFragment: [absPosStart, absPosEnd]
       } = config;
       let posEnd = activePos;
-      const isBodyActive = document.activeElement.tagName === 'BODY';
+      const isBodyActive = document.activeElement?.tagName === 'BODY';
       switch (key) {
         case 'ArrowUp':
         case 'ArrowRight':
@@ -318,12 +319,15 @@ function useKeyboard({
       }
       evt.stopPropagation();
       evt.preventDefault();
+      if (posEnd == null) {
+        return;
+      }
       setSelection({
         activePos: posEnd,
         anchorPos: posEnd,
         curSelecteds: [posEnd]
       });
-      containerRef.current.focus();
+      containerRef.current?.focus();
     },
     [config, handleKeyDown, setSelection, activePos, containerRef]
   );
@@ -344,6 +348,15 @@ function useKeyboard({
 }
 
 
+/**
+ * Mouse interaction logic for the sequence viewer.
+ *
+ * @param config - Rendering configuration for coordinate calculations.
+ * @param selectedPositions - Currently selected sequence positions.
+ * @param noBlurSelector - CSS selector for elements that should not trigger blur.
+ * @param selection - Current selection state managed by {@link useSelectionState}.
+ * @param setSelection - Setter function to update selection state.
+ */
 function useMouse({
   config,
   selectedPositions,
@@ -571,6 +584,14 @@ function useMouse({
 }
 
 
+/**
+ * Automatically scroll the viewport to keep the active position visible.
+ *
+ * @param activePos - Currently active sequence position.
+ * @param config - Rendering configuration used to translate positions to coordinates.
+ * @param footerHeight - Height of the footer, used to adjust viewport size.
+ * @returns Ref to the container div that should be scrolled.
+ */
 function useAutoScroll({
   activePos,
   config,
@@ -679,8 +700,8 @@ export default function SeqViewerStage({
     <div
      ref={containerRef}
      className={style['stage-container']}
-     tabIndex="0"
-     onKeyDown={handleKeyDown}>
+     tabIndex={0}
+     onKeyDown={e => handleKeyDown(e.nativeEvent)}>
       <Stage
        width={config.canvasWidthPixel}
        onMouseDown={handleMouseDown}
@@ -696,15 +717,14 @@ export default function SeqViewerStage({
          config={config}
          positionLookup={positionLookup} />
         <HoverLayer
-         hoverPos={selection.hoverPos}
+         hoverPos={selection.hoverPos ?? undefined}
          hoverUSAnnot={selection.hoverUSAnnot}
-         activePos={selection.activePos}
-         anchorPos={selection.anchorPos}
+         activePos={selection.activePos ?? undefined}
+         anchorPos={selection.anchorPos ?? undefined}
          config={config}
          positionLookup={positionLookup} />
         <SelectedLayer
          selectedPositions={selection.curSelecteds}
-         anchorPos={selection.anchorPos}
          config={config} />
       </Stage>
     </div>

--- a/src/views/mut-annot-viewer/components/legend-context/index.tsx
+++ b/src/views/mut-annot-viewer/components/legend-context/index.tsx
@@ -5,7 +5,7 @@ import React from 'react';
  * components of the mutation annotation viewer.
  */
 
-interface LegendContextValue {
+export interface LegendContextValue {
   colorBoxAnnotColorLookup: Record<string, {stroke?: string; bg?: string}>;
   underscoreAnnotColorLookup: Record<string, string>;
   aminoAcidsCatColorLookup: Record<string, string>;

--- a/src/views/mut-annot-viewer/components/viewer-controller/annot-category.tsx
+++ b/src/views/mut-annot-viewer/components/viewer-controller/annot-category.tsx
@@ -96,7 +96,7 @@ export default function AnnotCategory({
   );
 
   const handleToggle = React.useCallback(
-    (evt: React.MouseEvent<HTMLButtonElement>) => {
+    (evt: React.ChangeEvent<HTMLInputElement>) => {
       if (curAnnotNames && curAnnotNames.length) {
         onChange([]);
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2346,6 +2346,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.41.tgz#d0b939d94c1d7bd53d04824af45f1139b8c45615"
   integrity sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==
 
+"@types/pako@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-2.0.3.tgz#b6993334f3af27c158f3fe0dfeeba987c578afb1"
+  integrity sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
## Summary
- add explicit selection and keyboard handling types to sequence viewer stage
- solidify mutation annotation viewer data types and legend context
- refine hover overlays and position rendering to avoid implicit any usage

## Testing
- `yarn build` *(fails: many implicit any errors in config-generator.ts)*
- `yarn test -- --no-file-parallelism` *(fails: missing canvas module and several failing assertions)*

------
https://chatgpt.com/codex/tasks/task_e_6896d6a638548324bdd8a0992c58f72c