### PR TITLE
refactor: streamline react imports and typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
   },
   "devDependencies": {
     "@types/pako": "^2.0.3",
+    "canvas": "^3.1.2",
     "jsdom": "26.1.0",
     "sass-embedded": "^1.89.2",
     "vitest": "3.2.4"

--- a/src/components/ngs2codfreq/upload-form.tsx
+++ b/src/components/ngs2codfreq/upload-form.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useState, useCallback} from 'react';
 import pluralize from 'pluralize';
 import classNames from 'classnames';
 import Dropzone from 'react-dropzone';
@@ -33,9 +33,9 @@ export default function NGSUploadForm({
 }: NGSUploadFormProps) {
 
   const [config, isConfigPending] = ConfigContext.use();
-  const [fastqPairs, setFastqPairs] = React.useState<FastqPair[]>([]);
+  const [fastqPairs, setFastqPairs] = useState<FastqPair[]>([]);
 
-  const handleUpload = React.useCallback(
+  const handleUpload = useCallback(
     async (fileList: File[]) => {
       const fastqFiles: File[] = [];
       const knownFiles = new Set();
@@ -77,7 +77,7 @@ export default function NGSUploadForm({
     [fastqPairs, setFastqPairs]
   );
 
-  const handleSubmit = React.useCallback(
+  const handleSubmit = useCallback(
     e => {
       e && e.preventDefault();
       onSubmit && onSubmit(fastqPairs);
@@ -85,7 +85,7 @@ export default function NGSUploadForm({
     [onSubmit, fastqPairs]
   );
 
-  const handleReset = React.useCallback(
+  const handleReset = useCallback(
     e => {
       e && e.preventDefault();
       setFastqPairs([]);

--- a/src/components/ngs2codfreq/use-options.ts
+++ b/src/components/ngs2codfreq/use-options.ts
@@ -1,6 +1,7 @@
 import React from 'react';
 import set from 'lodash/set';
 import isEqual from 'lodash/isEqual';
+import {useState, useCallback, useMemo} from 'react';
 import createPersistedState from 'use-persisted-state/src';
 
 import {
@@ -29,7 +30,7 @@ const usePersistedOptions = createPersistedState(
  */
 export default function useOptions(): [NGSOptions, (key: string, value: any) => void, boolean] {
   const [persistedOptions, setPersistedOptions] = usePersistedOptions({});
-  const [options, setOptions] = React.useState<NGSOptions>({
+  const [options, setOptions] = useState<NGSOptions>({
     fastpConfig: {...defaultFastpConfig},
     cutadaptConfig: {...defaultCutadaptConfig},
     ivarConfig: {...defaultIvarConfig},
@@ -38,7 +39,7 @@ export default function useOptions(): [NGSOptions, (key: string, value: any) => 
     ...persistedOptions
   });
 
-  const onChange = React.useCallback(
+  const onChange = useCallback(
     (key: string, value: any) => {
       const newOptions: NGSOptions = {...options};
       if (key === '.') {
@@ -60,7 +61,7 @@ export default function useOptions(): [NGSOptions, (key: string, value: any) => 
     [options, setPersistedOptions]
   );
 
-  const isDefault = React.useMemo(
+  const isDefault = useMemo(
     () => {
       const {
         fastpConfig,

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="vite/client" />
+
 declare module '*.module.scss' {
   const classes: { readonly [key: string]: string };
   export default classes;
@@ -11,4 +13,9 @@ declare module './views/mut-annot-viewer' {
 declare module './views/mut-annot-viewer/*' {
   const value: any;
   export default value;
+}
+
+interface Window {
+  /** Node environment string injected at build time */
+  __NODE_ENV?: string;
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {createRoot} from 'react-dom/client';
 import {
   BrowserProtocol,

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {Route} from 'found';
 
 import Layout from './components/layout';

--- a/src/utils/config-context.ts
+++ b/src/utils/config-context.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useCallback} from 'react';
 import memoize from 'lodash/memoize';
 
 import createAsyncContext from './async-context';
@@ -18,7 +18,7 @@ const fetchConfig = memoize(
  * merging local and remote settings.
  */
 export function useConfigLoader<T extends {configFromURL?: string}>(config: T) {
-  return React.useCallback(
+  return useCallback(
     async () => {
       let loadedConfig: Record<string, any>;
       if (config.configFromURL) {

--- a/src/utils/nl2br.tsx
+++ b/src/utils/nl2br.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import type {ReactNode} from 'react';
 
 const newLineRegex = /(\r\n|\n\r|\r|\n)/g;
 
@@ -13,7 +13,7 @@ const newLineRegex = /(\r\n|\n\r|\r|\n)/g;
  * @returns Array of strings and `<br/>` elements representing the original
  * newline boundaries.
  */
-export default function nl2br(text: string): React.ReactNode[] {
+export default function nl2br(text: string): ReactNode[] {
   return text.split(newLineRegex).map((line, idx) => {
     if (newLineRegex.test(line)) {
       return <br key={idx} />;

--- a/src/views/hbv/tabular-report-by-sequences/index.tsx
+++ b/src/views/hbv/tabular-report-by-sequences/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ReactElement, useMemo } from 'react';
 import {useRouter} from 'found';
 import useApolloClient from '../apollo-client';
 
@@ -31,7 +31,7 @@ export default function TabularReportBySequencesContainer({
   sequences,
   onFinish,
   patternsTo
-}: TabularReportBySequencesProps): JSX.Element {
+}: TabularReportBySequencesProps): ReactElement | null {
 
   const {match} = useRouter();
   const [config, isConfigPending] = ConfigContext.use();
@@ -46,7 +46,7 @@ export default function TabularReportBySequencesContainer({
     match
   });
 
-  const curSubOptions = React.useMemo(
+  const curSubOptions = useMemo(
     () => subOptions.filter((_, idx) => subOptionIndices.includes(idx)),
     [subOptionIndices]
   );

--- a/src/views/hiv/apollo-client.ts
+++ b/src/views/hiv/apollo-client.ts
@@ -1,5 +1,4 @@
-import React from 'react';
-import React from 'react';
+import { useRef } from 'react';
 import isEqual from 'lodash/isEqual';
 import {
   ApolloClient,
@@ -71,7 +70,7 @@ export default function useApolloClient({
   skip = false,
   payload
 }: UseApolloClientArgs): ApolloClient<any> | null {
-  const { current } = React.useRef<{ client?: ApolloClient<any>; payload?: unknown }>({});
+  const { current } = useRef<{ client?: ApolloClient<any>; payload?: unknown }>({});
   if (skip) {
     return null;
   }

--- a/src/views/hiv/config.ts
+++ b/src/views/hiv/config.ts
@@ -2,17 +2,19 @@
  * Default configuration for the HIV views.
  * Values are largely driven by the deployment environment and CMS settings.
  */
+const NODE_ENV = window.__NODE_ENV;
+
 const config: Record<string, any> = {
   configFromURL: (
     'https://s3-us-west-2.amazonaws.com/cms.hivdb.org/localhost/' +
     'pages/sierra-hivpol.json'
   ),
   graphqlURI: (
-    window.__NODE_ENV === 'production' ?
+    NODE_ENV === 'production' ?
       '/graphql' :
       'http://localhost:8111/sierra/rest/graphql'),
   server_host: (
-    window.__NODE_ENV === 'production' ?
+    NODE_ENV === 'production' ?
       '' : 'http://localhost:8111'
   ),
   cmsStages: {

--- a/src/views/hiv/forms/algorithm-selector.tsx
+++ b/src/views/hiv/forms/algorithm-selector.tsx
@@ -1,4 +1,11 @@
-import React from 'react';
+import {
+  ReactElement,
+  ReactNode,
+  useCallback,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import readFile from '../../../utils/read-file';
 import BigData from '../../../utils/big-data';
 import useMounted from '../../../utils/use-mounted';
@@ -11,16 +18,24 @@ import AlgVerSelect, {
 import style from './style.module.scss';
 
 interface SelectedAlgorithmProps {
-  children: React.ReactNode;
+  /** Content of the algorithm item */
+  children: ReactNode;
+  /** Callback when the item is removed */
   onRemove: () => void;
 }
 
+/**
+ * Display a selected algorithm with a remove button.
+ *
+ * @param props - {@link SelectedAlgorithmProps}
+ * @returns Rendered algorithm element.
+ */
 function SelectedAlgorithm({
   children,
   onRemove
 }: SelectedAlgorithmProps) {
-  const handleRemove = React.useCallback(
-    event => {
+  const handleRemove = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
       event.preventDefault();
       onRemove();
     },
@@ -51,24 +66,36 @@ function isCustomAlg(value: string): boolean {
   return value.startsWith('CUSTOM-ALG-');
 }
 
+interface AlgorithmSelectorConfig {
+  messages: Record<string, string>;
+  algorithmVersions: Record<string, any[]>;
+  excludeAlgorithmVersions: string[];
+}
+
 interface AlgorithmSelectorProps {
-  config: { messages: Record<string, string> };
-  algorithms: Record<string, { value: string; label: React.ReactNode; xml?: string }>;
+  config: AlgorithmSelectorConfig;
+  algorithms: Record<string, { value: string; label: ReactNode; xml?: string }>;
   onChange: (algs: Record<string, any>) => void;
 }
 
+/**
+ * Render algorithm selection inputs with support for custom uploads.
+ *
+ * @param props - {@link AlgorithmSelectorProps}
+ * @returns Fieldset element containing algorithm selection UI.
+ */
 function AlgorithmSelector({
   config,
   algorithms,
   onChange
 }: AlgorithmSelectorProps) {
   const {messages} = config;
-  const [checkboxError, setCheckboxError] = React.useState<string | null>(null);
+  const [checkboxError, setCheckboxError] = useState<string | null>(null);
 
   const isMounted = useMounted();
 
-  const timeoutLock = React.useRef<NodeJS.Timeout | null>(null);
-  const setTimeoutClearError = React.useCallback(
+  const timeoutLock = useRef<NodeJS.Timeout | null>(null);
+  const setTimeoutClearError = useCallback(
     () => {
       if (timeoutLock.current !== null) {
         clearTimeout(timeoutLock.current);
@@ -83,15 +110,15 @@ function AlgorithmSelector({
     [setCheckboxError, isMounted]
   );
 
-  const handleAdd = React.useCallback(
-    ({ value, label }: { value: string; label: React.ReactNode }) => {
+  const handleAdd = useCallback(
+    ({ value, label }: { value: string; label: ReactNode }) => {
       algorithms[value] = { value, label };
       onChange(algorithms);
     },
     [algorithms, onChange]
   );
 
-  const handleRemove = React.useCallback(
+  const handleRemove = useCallback(
     (name: string) => {
       if (Object.keys(algorithms).length > 2) {
         delete algorithms[name];
@@ -105,7 +132,7 @@ function AlgorithmSelector({
     [algorithms, onChange, setTimeoutClearError]
   );
 
-  const handleUpload = React.useCallback(
+  const handleUpload = useCallback(
     async (fileList: FileList | File[]) => {
       fileList = [...(fileList as any)];
       if (fileList.length === 0) {
@@ -186,13 +213,13 @@ function AlgorithmSelector({
  * @param config - Configuration including available algorithm versions.
  * @returns Tuple of rendered selector component and submit-state fetcher.
  */
-export default function useAlgorithmSelector(config: any): [JSX.Element | null, () => Promise<{ algorithms: string[]; customAlgorithms: any }>] {
+export default function useAlgorithmSelector(config: any): [ReactElement | null, () => Promise<{ algorithms: string[]; customAlgorithms: any }>] {
   const {
     algorithmVersions,
     excludeAlgorithmVersions
   } = config;
 
-  const defaultAlgorithms = React.useMemo(
+  const defaultAlgorithms = useMemo(
     () => algorithmVersions ? getLatestVersions({
       algorithmVersions,
       excludeAlgorithmVersions
@@ -203,9 +230,9 @@ export default function useAlgorithmSelector(config: any): [JSX.Element | null, 
     [algorithmVersions, excludeAlgorithmVersions]
   );
 
-  const [algorithms, setAlgorithms] = React.useState<Record<string, any>>(defaultAlgorithms);
+  const [algorithms, setAlgorithms] = useState<Record<string, any>>(defaultAlgorithms);
 
-  const getAlgorithms = React.useCallback(() => {
+  const getAlgorithms = useCallback(() => {
     const publicAlgorithms = Object.keys(algorithms).filter(alg => !isCustomAlg(alg));
     const customAlgorithms = Object.keys(algorithms)
       .filter(alg => isCustomAlg(alg))
@@ -217,7 +244,7 @@ export default function useAlgorithmSelector(config: any): [JSX.Element | null, 
     return [publicAlgorithms, customAlgorithms];
   }, [algorithms]);
 
-  const getSubmitState = React.useCallback(async () => {
+  const getSubmitState = useCallback(async () => {
     let [algorithmsList, customAlgorithms] = getAlgorithms();
     customAlgorithms = await BigData.save(customAlgorithms);
     return { algorithms: algorithmsList, customAlgorithms };

--- a/src/views/hiv/forms/drug-display-options.tsx
+++ b/src/views/hiv/forms/drug-display-options.tsx
@@ -1,4 +1,9 @@
-import React from 'react';
+import {
+  ReactElement,
+  useCallback,
+  useMemo,
+  useState
+} from 'react';
 
 import Markdown from '../../../components/markdown';
 import Link from '../../../components/link';
@@ -16,6 +21,12 @@ interface DrugDisplayOptionsProps {
   onReset: (e: React.MouseEvent) => void;
 }
 
+/**
+ * Render checkboxes for enabling or disabling drug display options.
+ *
+ * @param props - {@link DrugDisplayOptionsProps}
+ * @returns Fieldset element containing controls for drug display.
+ */
 function DrugDisplayOptions({
   drugDisplayOptions,
   drugDisplayNames,
@@ -75,13 +86,13 @@ function DrugDisplayOptions({
  * @param config - Configuration including drug display options and messages.
  * @returns Tuple containing component and submit-state getter.
  */
-export default function useDrugDisplayOptions(config: any): [JSX.Element | null, () => { disabledDrugs: string[] }] {
+export default function useDrugDisplayOptions(config: any): [ReactElement | null, () => { disabledDrugs: string[] }] {
   const {
     drugDisplayOptions,
     drugDisplayNames,
     messages
   } = config;
-  const defaultUncheckedDrugs = React.useMemo(
+  const defaultUncheckedDrugs = useMemo(
     () =>
       Object.values(drugDisplayOptions || {}).reduce(
         (acc: string[], { drugs }: any) => [
@@ -93,9 +104,9 @@ export default function useDrugDisplayOptions(config: any): [JSX.Element | null,
     [drugDisplayOptions]
   );
 
-  const [uncheckedDrugs, setUncheckedDrugs] = React.useState<Set<string>>(new Set(defaultUncheckedDrugs));
+  const [uncheckedDrugs, setUncheckedDrugs] = useState<Set<string>>(new Set(defaultUncheckedDrugs));
 
-  const handleChange = React.useCallback(
+  const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const drug = e.currentTarget.value;
       const newUncheckedDrugs = new Set(uncheckedDrugs);
@@ -109,7 +120,7 @@ export default function useDrugDisplayOptions(config: any): [JSX.Element | null,
     [uncheckedDrugs]
   );
 
-  const handleSelectAll = React.useCallback(
+  const handleSelectAll = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       setUncheckedDrugs(new Set());
@@ -117,7 +128,7 @@ export default function useDrugDisplayOptions(config: any): [JSX.Element | null,
     []
   );
 
-  const handleReset = React.useCallback(
+  const handleReset = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
       setUncheckedDrugs(new Set(defaultUncheckedDrugs));
@@ -125,7 +136,7 @@ export default function useDrugDisplayOptions(config: any): [JSX.Element | null,
     [defaultUncheckedDrugs]
   );
 
-  const getSubmitState = React.useCallback(
+  const getSubmitState = useCallback(
     () => ({ disabledDrugs: Array.from(uncheckedDrugs) }),
     [uncheckedDrugs]
   );

--- a/src/views/hiv/forms/index.tsx
+++ b/src/views/hiv/forms/index.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import React from 'react';
+import { useCallback, useMemo } from 'react';
 import {Router, Match} from 'found';
 
 import {getFullLink} from '../../../utils/cms';
@@ -52,7 +51,7 @@ function loadExampleFasta(examples: Array<{url: string; title: string}>, config:
  */
 function useTabularReportOptions({config, match, allSubOptions}: any) {
   const {formEnableTabularReportOptions} = config;
-  return React.useMemo(
+  return useMemo(
     () => {
       const options = [...(formEnableTabularReportOptions || [])];
       if (
@@ -114,7 +113,7 @@ function SierraForms({
     getAlgSubmitState
   ] = useAlgorithmSelector(config);
 
-  const getSubmitState = React.useCallback(
+  const getSubmitState = useCallback(
     async () => ({
       ...await getDrugSubmitState(),
       ...await getAlgSubmitState()
@@ -127,7 +126,7 @@ function SierraForms({
   // );
   // const showAlgOpt = true;
 
-  const handleSubmit = React.useCallback(
+  const handleSubmit = useCallback(
     async () => {
       return [true, await getSubmitState()];
     },

--- a/src/views/hiv/tabular-report/hiv-seq-summary.ts
+++ b/src/views/hiv/tabular-report/hiv-seq-summary.ts
@@ -62,15 +62,15 @@ async function seqSummary({
 }: any): Promise<any[]> {
   const rows = [];
   const {geneDisplay} = config;
-  const mutTypeHeaders = allGenes.reduce(
-    (acc, {name: geneName, drugClasses}) => [
+  const mutTypeHeaders = (allGenes as any[]).reduce(
+    (acc: any, {name: geneName, drugClasses}: any) => [
       ...acc,
-      ...drugClasses.reduce(
-        (acc2, {name: dcName, mutationTypes}) => [
+        ...drugClasses.reduce(
+          (acc2: any, {name: dcName, mutationTypes}: any) => [
           ...acc2,
           ...mutationTypes
-            .filter(mtype => mtype !== 'Other')
-            .map(mtype => mtype === dcName ? mtype : `${dcName} ${mtype}`)
+            .filter((mtype: any) => mtype !== 'Other')
+            .map((mtype: any) => mtype === dcName ? mtype : `${dcName} ${mtype}`)
         ],
         []
       ),
@@ -78,13 +78,13 @@ async function seqSummary({
     ],
     []
   );
-  const allGeneNames = allGenes.map(({name}) => name);
+  const allGeneNames = (allGenes as any[]).map(({name}: any) => name);
 
   const header = [
     'Sequence Name',
     'Genes',
-    ...allGenes.reduce(
-      (acc, {name}) => [
+    ...(allGenes as any[]).reduce(
+      (acc: any, {name}: any) => [
         ...acc,
         `${name} Start`,
         `${name} End`
@@ -97,23 +97,23 @@ async function seqSummary({
     ] : []),
     'NA Mixture Rate (%)',
     ...mutTypeHeaders,
-    ...allGenes.reduce(
-      (acc, {drugClasses}) => [
+    ...(allGenes as any[]).reduce(
+      (acc: any, {drugClasses}: any) => [
         ...acc,
         ...drugClasses
           .filter(
-            ({hasSurveilDrugResistMutations: hasSDRMs}) => hasSDRMs
+            ({hasSurveilDrugResistMutations: hasSDRMs}: any) => hasSDRMs
           )
-          .map(({name}) => `${name} SDRMs`)
+          .map(({name}: any) => `${name} SDRMs`)
       ],
       []
     ),
-    ...allGenes.reduce(
-      (acc, {drugClasses}) => [
+    ...(allGenes as any[]).reduce(
+      (acc: any, {drugClasses}: any) => [
         ...acc,
         ...drugClasses
-          .filter(({hasRxSelectedMutations: hasTSMs}) => hasTSMs)
-          .map(({name}) => `${name} TSMs`)
+          .filter(({hasRxSelectedMutations: hasTSMs}: any) => hasTSMs)
+          .map(({name}: any) => `${name} TSMs`)
       ],
       []
     ),
@@ -166,7 +166,7 @@ async function seqSummary({
       ambiguousMutations,
       apobecMutations
     } = seqResult;
-    let row = {
+    const row: Record<string, unknown> = {
       'Sequence Name': seqName1 || seqName2,
       'Genes': genes
         .filter(({name}) => allGeneNames.includes(name))
@@ -202,12 +202,12 @@ async function seqSummary({
       row['Frame Shifts'] = getObjectText(frameShifts);
       row['Num Frame Shifts'] = `${frameShifts.length}`;
     }
-    for (const {gene: {name: geneName}, mutationsByTypes} of geneDRs) {
+    for (const {gene: {name: geneName}, mutationsByTypes} of geneDRs as any[]) {
       for (const {
         drugClass,
         mutationType,
         mutations
-      } of mutationsByTypes) {
+      } of mutationsByTypes as any[]) {
         let mutTypeHdr;
         if (drugClass) {
           if (drugClass.name === mutationType) {
@@ -229,16 +229,16 @@ async function seqSummary({
       lastAA,
       sdrms,
       tsms
-    } of geneSeqs1 || geneSeqs2) {
+    } of (geneSeqs1 || geneSeqs2) as any[]) {
       row[`${geneText} Start`] = firstAA;
       row[`${geneText} End`] = lastAA;
-      const {drugClasses} = allGenes.find(({name}) => geneText === name);
-      for (const {name: dcText} of drugClasses) {
+      const {drugClasses} = allGenes.find(({name}: {name: string}) => geneText === name)!;
+      for (const {name: dcText} of drugClasses as Array<{name: string}>) {
         row[`${dcText} SDRMs`] = getObjectTextNoGene(
-          sdrms.filter(({SDRMDrugClass: dc}) => dcText === dc?.name)
+          sdrms.filter(({SDRMDrugClass: dc}: any) => dcText === dc?.name)
         );
         row[`${dcText} TSMs`] = getObjectTextNoGene(
-          tsms.filter(({TSMDrugClass: dc}) => dcText === dc?.name)
+          tsms.filter(({TSMDrugClass: dc}: any) => dcText === dc?.name)
         );
       }
     }

--- a/src/views/hiv/use-disabled-drugs.ts
+++ b/src/views/hiv/use-disabled-drugs.ts
@@ -7,6 +7,6 @@ import useLocation from 'found/useLocation';
  * @returns Array of disabled drug identifiers.
  */
 export default function useDisabledDrugs(): string[] {
-  const { state: { disabledDrugs = [] } = {} } = useLocation<any>();
+  const {state: {disabledDrugs = []} = {}} = useLocation();
   return disabledDrugs as string[];
 }

--- a/src/views/hiv/use-extend-variables.ts
+++ b/src/views/hiv/use-extend-variables.ts
@@ -50,7 +50,7 @@ export default function useExtendVariables({
           }
         }
       })();
-      return () => mounted = false;
+      return () => { mounted = false; };
     },
     [match.location?.state, getSubmitState]
   );

--- a/src/views/hiv/use-extend-variables.ts
+++ b/src/views/hiv/use-extend-variables.ts
@@ -1,5 +1,4 @@
-import React from 'react';
-import React from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'found';
 import BigData from '../../utils/big-data';
 
@@ -25,10 +24,10 @@ export default function useExtendVariables({
   config
 }: UseExtendVariablesArgs): [(vars: Record<string, any>) => Record<string, any>, boolean] {
   const {allGenes} = config;
-  const [extendVars, setExtendVars] = React.useState<Record<string, any> | null>(null);
+  const [extendVars, setExtendVars] = useState<Record<string, any> | null>(null);
   const {match} = useRouter();
 
-  React.useEffect(
+  useEffect(
     () => {
       let mounted = true;
       setExtendVars(null);
@@ -57,7 +56,7 @@ export default function useExtendVariables({
   );
 
   return [
-    React.useCallback(
+    useCallback(
       (vars: Record<string, any>) => {
         for (const key of SUBMIT_STATE_ALLOWLIST) {
           if (extendVars && key in extendVars) {

--- a/src/views/markdown-debugger/index.tsx
+++ b/src/views/markdown-debugger/index.tsx
@@ -61,7 +61,9 @@ export default function MarkdownDebugger() {
       escapeHtml={false}
       tables={tableData}
       refDataLoader={RefDataLoader}
-      collapsableLevels={['h3']}
+      // TODO: correct typings when Markdown collapsable levels support string identifiers
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      collapsableLevels={['h3'] as any}
       genomeMaps={genomeMaps}
     >
       {testMd}

--- a/src/views/markdown-debugger/index.tsx
+++ b/src/views/markdown-debugger/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect } from 'react';
 import Markdown from '../../components/markdown';
 import genomeMaps from './genome-maps.json';
 import tableData from './table-data.json';
@@ -25,13 +25,16 @@ interface RefDataLoaderProps {
 
 /**
  * Loads reference data asynchronously and notifies the parent component.
+ *
+ * @param props - {@link RefDataLoaderProps}
+ * @returns `null` once side effects are registered.
  */
 function RefDataLoader({
   onLoad,
   setReference,
   references
 }: RefDataLoaderProps) {
-  React.useEffect(() => {
+  useEffect(() => {
     const timer = setTimeout(() => {
       for (const ref of references) {
         setReference(ref.name, {...ref, children: `${ref.name}aaaa`}, false);

--- a/src/views/markdown-debugger2/index.tsx
+++ b/src/views/markdown-debugger2/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { useEffect } from 'react';
 import Markdown from '../../components/markdown';
 import genomeMaps from './genome-maps.json';
 import tableData from './table-data.json';
@@ -25,13 +25,16 @@ interface RefDataLoaderProps {
 
 /**
  * Injects reference data after a short delay to mimic async behaviour.
+ *
+ * @param props - {@link RefDataLoaderProps}
+ * @returns `null` once side effects are registered.
  */
 function RefDataLoader({
   onLoad,
   setReference,
   references
 }: RefDataLoaderProps) {
-  React.useEffect(() => {
+  useEffect(() => {
     const timer = setTimeout(() => {
       for (const ref of references) {
         setReference(ref.name, {...ref, children: `${ref.name}aaaa`}, false);

--- a/src/views/mut-annot-viewer/components/canvas-sequence-viewer/config-generator.ts
+++ b/src/views/mut-annot-viewer/components/canvas-sequence-viewer/config-generator.ts
@@ -78,7 +78,6 @@ export default class ConfigGenerator {
       baseSizePixel
     });
     this.initGridConfig({
-      baseSizePixel,
       canvasWidthPixel,
       seqFragment
     });
@@ -91,11 +90,9 @@ export default class ConfigGenerator {
       underscoreAnnotNames
     });
     this.initCoordConfig({
-      baseSizePixel,
-      underscoreAnnotNames,
-      aminoAcidsAnnotPositions
+      baseSizePixel
     });
-    this.initColorConfig({});
+    this.initColorConfig();
   }
 
   getHash() {
@@ -124,9 +121,14 @@ export default class ConfigGenerator {
     );
   }
 
+  /**
+   * Establish base measurements for sequence viewer elements.
+   *
+   * @param baseSizePixel - Base pixel unit for layout sizing.
+   */
   initSizeConfig({
     baseSizePixel
-  }) {
+  }: {baseSizePixel: number}) {
     const posItemSizePixel = baseSizePixel;
     const horizontalMarginPixel = baseSizePixel / 5;
     const underscoreAnnotHeightPixel = baseSizePixel / 8;
@@ -163,7 +165,13 @@ export default class ConfigGenerator {
     });
   }
 
-  initGridConfig({canvasWidthPixel, seqFragment}) {
+  /**
+   * Initialize grid dimensions and related counts.
+   *
+   * @param canvasWidthPixel - Width of the drawing canvas in pixels.
+   * @param seqFragment - Inclusive sequence fragment [start, end].
+   */
+  initGridConfig({canvasWidthPixel, seqFragment}: {canvasWidthPixel: number; seqFragment: [number, number]}) {
     const {
       posItemOuterWidthPixel
     } = this;
@@ -180,10 +188,16 @@ export default class ConfigGenerator {
     });
   }
 
+  /**
+   * Calculate offsets for underscore and amino-acid annotations.
+   *
+   * @param underscoreAnnotLocations - Location matrix for underscore annotations.
+   * @param aminoAcidsAnnotPositions - Annotation positions for amino acids.
+   */
   initAnnotsConfig({
     underscoreAnnotLocations,
     aminoAcidsAnnotPositions
-  }) {
+  }: {underscoreAnnotLocations: {matrix?: unknown[]}; aminoAcidsAnnotPositions: Record<number, unknown>[]}) {
     const {
       numCols,
       numRows,
@@ -207,13 +221,13 @@ export default class ConfigGenerator {
       const posEnd = (r + 1) * numCols + absPosStart - 1;
       const annotHeightPerPos = new Array(numCols).fill(0);
       for (let pos = posStart; pos <= posEnd; pos ++) {
-        const posLocs = usLocMatrix[pos - 1];
-        if (posLocs && posLocs.length > 0) {
+        const posLocs = (usLocMatrix[pos - 1] as any[]) || [];
+        if (posLocs.length > 0) {
           annotHeightPerPos[pos - posStart] += posLocs.length * usOuterSize;
         }
       }
       for (const positions of aminoAcidsAnnotPositions) {
-        for (const [pos,, aas] of Object.values(positions)) {
+        for (const [pos,, aas] of Object.values(positions) as Array<[number, unknown, any[]]>) {
           if (pos < posStart) {
             continue;
           }
@@ -234,7 +248,13 @@ export default class ConfigGenerator {
     });
   }
 
-  initCanvasConfig({seqFragment, underscoreAnnotNames}) {
+  /**
+   * Compute overall canvas dimensions.
+   *
+   * @param seqFragment - Inclusive sequence fragment [start, end].
+   * @param underscoreAnnotNames - List of underscore annotation names.
+   */
+  initCanvasConfig({seqFragment, underscoreAnnotNames}: {seqFragment: [number, number]; underscoreAnnotNames: string[]}) {
     const {
       numCols,
       posItemOuterHeightPixel,
@@ -253,16 +273,21 @@ export default class ConfigGenerator {
         verticalMarginPixel +
         Math.ceil(seqFragmentLen / numCols) *
         posItemOuterHeightPixel +
-        underscoreAnnotOffsetYPixelPerRow.reduce((sum, px) => sum + px, 0) +
+        underscoreAnnotOffsetYPixelPerRow.reduce((sum: number, px: number) => sum + px, 0) +
         verticalMarginPixel +
         underscoreAnnotNames.length * underscoreAnnotOuterSize
       )
     });
   }
 
+  /**
+   * Establish coordinate offsets for each grid row.
+   *
+   * @param baseSizePixel - Base pixel size for layout calculations.
+   */
   initCoordConfig({
     baseSizePixel
-  }) {
+  }: {baseSizePixel: number}) {
     const {
       numRows,
       verticalMarginPixel: vMargin,
@@ -325,7 +350,15 @@ export default class ConfigGenerator {
     });
   }
 
-  posRange2CoordPairs = (posStart, posEnd, locIndex) => {
+  /**
+   * Convert a position range into start/end coordinate pairs.
+   *
+   * @param posStart - Start position.
+   * @param posEnd - End position.
+   * @param locIndex - Annotation location index.
+   * @returns Array of coordinate pair objects.
+   */
+  posRange2CoordPairs = (posStart: number, posEnd: number, locIndex: number) => {
     const {
       numCols,
       posItemSizePixel,
@@ -369,7 +402,14 @@ export default class ConfigGenerator {
     return coordPairs;
   };
 
-  posAA2Coord = (pos, aaOffsetIndex) => {
+  /**
+   * Resolve coordinates for an amino-acid annotation at a position.
+   *
+   * @param pos - Sequence position.
+   * @param aaOffsetIndex - Offset index of the amino acid.
+   * @returns Coordinate object.
+   */
+  posAA2Coord = (pos: number, aaOffsetIndex: number) => {
     const {
       posItemSizePixel,
       underscoreAnnotLocations,
@@ -396,7 +436,13 @@ export default class ConfigGenerator {
     };
   };
 
-  pos2Coord = (pos) => {
+  /**
+   * Map a sequence position to x/y coordinates.
+   *
+   * @param pos - Sequence position.
+   * @returns Coordinate object or empty object if out of range.
+   */
+  pos2Coord = (pos: number): {x?: number; y?: number} => {
     const [posStart, posEnd] = this.seqFragment;
     if (!pos || pos < posStart || pos > posEnd) {
       return {};
@@ -425,10 +471,13 @@ export default class ConfigGenerator {
     const usHeight = underscoreAnnotHeightPixel + underscoreAnnotMarginPixel;
 
     const pos = this.coord2Pos(x, y);
-    const posAnnots = matrix[pos - 1] || [];
-    const {x: baseX, y: baseY} = this.pos2Coord(pos);
+    if (pos == null) {
+      return {};
+    }
+    const posAnnots = (matrix[pos - 1] as string[]) || [];
+    const {x: baseX, y: baseY} = this.pos2Coord(pos) as {x: number; y: number};
     const relY = y - baseY - offsetY;
-    const locIdx = parseInt(relY / usHeight);
+    const locIdx = Math.floor(relY / usHeight);
     if (locIdx >= 0 && locIdx < posAnnots.length) {
       return {
         annotName: posAnnots[locIdx],
@@ -497,17 +546,23 @@ export default class ConfigGenerator {
         lookup = this.circleInBoxPositions;
         break;
       default:
-        return [];
+        return {} as Record<number, unknown>;
     }
     return lookup;
   }
 
+  /**
+   * Retrieve amino-acid annotations for a given position.
+   *
+   * @param pos - Sequence position.
+   * @returns Array of amino acid definitions with colors and offsets.
+   */
   getAnnotatedAAs = (pos: number) => {
     const aaDefs: Array<{aminoAcid: string; offsetPixel: {x: number; y: number}; color: string}> = [];
     let globalIdxOffset = 0;
     const {aminoAcidsOverrideColors} = this;
     for (const lookup of this.aminoAcidsAnnotPositions) {
-      const posDef = lookup[pos];
+      const posDef = lookup[pos] as [number, number, string[]];
       if (!posDef) {
         continue;
       }
@@ -535,7 +590,7 @@ export default class ConfigGenerator {
 
   getColorIndex = (pos: number, annotStyle: string): number | undefined => {
     const lookup = this.getAnnotPosLookup(annotStyle);
-    const posDef = lookup[pos];
+    const posDef = lookup[pos] as [unknown, number, unknown];
     if (posDef) {
       const [, colorIdx] = posDef;
       return colorIdx;

--- a/src/views/mut-annot-viewer/components/viewer-legend/color-legend.tsx
+++ b/src/views/mut-annot-viewer/components/viewer-legend/color-legend.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useMemo} from 'react';
 import makeClassNames from 'classnames';
 import range from 'lodash/range';
 
@@ -303,7 +303,7 @@ export default function ColorLegend({
   citations
 }: ColorLegendProps) {
 
-  const annotObjs = React.useMemo(
+  const annotObjs = useMemo(
     () => getAllAnnotations({
       positionLookup,
       seqFragment,

--- a/src/views/mut-annot-viewer/components/viewer-legend/index.tsx
+++ b/src/views/mut-annot-viewer/components/viewer-legend/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useMemo} from 'react';
 import makeClassNames from 'classnames';
 
 import type {
@@ -40,7 +40,7 @@ export default function Legend({
   annotations
 }: LegendProps) {
 
-  const colorBoxAnnotDef = React.useMemo(() => {
+  const colorBoxAnnotDef = useMemo(() => {
     const category = annotCategories.find(({annotStyle}) => annotStyle === 'colorBox');
     if (!category) {
       return undefined;
@@ -50,7 +50,7 @@ export default function Legend({
     return annotations.find(({name}) => name === annotName);
   }, [curAnnotNameLookup, annotCategories, annotations])!;
 
-  const circleInBoxAnnotDef = React.useMemo(
+  const circleInBoxAnnotDef = useMemo(
     () => {
       const category = (
         annotCategories

--- a/src/views/mut-annot-viewer/preset-selection.tsx
+++ b/src/views/mut-annot-viewer/preset-selection.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import {useCallback} from 'react';
 import Dropdown from 'react-dropdown';
 
 import style from './style.module.scss';
@@ -26,7 +26,7 @@ interface PresetSelectionProps {
  * @returns A section element containing the dropdown control.
  */
 export default function PresetSelection({match: {location}, router, options}: PresetSelectionProps) {
-  const handleChange = React.useCallback(
+  const handleChange = useCallback(
     ({value}: {value: string}) => router.push(`${location.pathname}${value}/`),
     [router, location]
   );

--- a/src/views/mut-annot-viewer/viewer.test.tsx
+++ b/src/views/mut-annot-viewer/viewer.test.tsx
@@ -1,5 +1,4 @@
 import '@testing-library/jest-dom';
-import React from 'react';
 import {render, waitFor} from '@testing-library/react';
 import MutAnnotViewer from './viewer';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2785,6 +2785,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2794,6 +2799,15 @@ binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+bl@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.1.0.tgz#451535264182bec2fbbc83a62ab98cf11d9f7b3a"
+  integrity sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2841,6 +2855,14 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer@^5.5.0:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
+
 cac@^6.7.14:
   version "6.7.14"
   resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
@@ -2868,6 +2890,14 @@ caniuse-lite@^1.0.30001726:
   version "1.0.30001731"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz#277c07416ea4613ec564e5b0ffb47e7b60f32e2f"
   integrity sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==
+
+canvas@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/canvas/-/canvas-3.1.2.tgz#a98406ef6178d31e39eb7dc0a488b1181555b792"
+  integrity sha512-Z/tzFAcBzoCvJlOSlCnoekh1Gu8YMn0J51+UAuXJAbW1Z6I9l2mZgdD7738MepoeeIcUdDtbMnOg6cC7GJxy/g==
+  dependencies:
+    node-addon-api "^7.0.0"
+    prebuild-install "^7.1.3"
 
 cfb@~1.2.1:
   version "1.2.2"
@@ -2946,6 +2976,11 @@ chokidar@^3.4.0:
     readdirp "~3.5.0"
   optionalDependencies:
     fsevents "~2.3.1"
+
+chownr@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
+  integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
 classnames@*, classnames@^2.2.3, classnames@^2.2.4, classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
@@ -3316,10 +3351,22 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
+decompress-response@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
+  integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
+  dependencies:
+    mimic-response "^3.1.0"
+
 deep-eql@^5.0.1:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
   integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
+
+deep-extend@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
+  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 define-properties@^1.1.3:
   version "1.1.3"
@@ -3342,6 +3389,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-libc@^2.0.0:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.0.4.tgz#f04715b8ba815e53b4d8109655b6508a6865a7e8"
+  integrity sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==
 
 dom-accessibility-api@^0.5.9:
   version "0.5.14"
@@ -3449,6 +3501,13 @@ encoding@^0.1.11:
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
   dependencies:
     iconv-lite "^0.6.2"
+
+end-of-stream@^1.1.0, end-of-stream@^1.4.1:
+  version "1.4.5"
+  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.5.tgz#7344d711dea40e0b74abc2ed49778743ccedb08c"
+  integrity sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==
+  dependencies:
+    once "^1.4.0"
 
 enquire.js@^2.1.6:
   version "2.1.6"
@@ -3612,6 +3671,11 @@ exit-on-epipe@~1.0.1:
   resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
   integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
 
+expand-template@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-2.0.3.tgz#6e14b3fcee0f3a6340ecb57d2e8918692052a47c"
+  integrity sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==
+
 expect-type@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.2.2.tgz#c030a329fb61184126c8447585bc75a7ec6fbff3"
@@ -3748,6 +3812,11 @@ frac@~1.1.2:
   resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
   integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
+fs-constants@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
+  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
+
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
@@ -3786,6 +3855,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
+
+github-from-package@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
+  integrity sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==
 
 glob-parent@~5.1.0, glob-parent@~5.1.2:
   version "5.1.2"
@@ -3990,6 +4064,11 @@ iconv-lite@^0.6.2:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
@@ -4026,10 +4105,15 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.0, inherits@~2.0.3:
+inherits@2, inherits@^2.0.0, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+ini@~1.3.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 inline-style-parser@0.1.1:
   version "0.1.1"
@@ -4533,6 +4617,11 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.47.0"
 
+mimic-response@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
+  integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
+
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -4545,10 +4634,20 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@^1.2.0, minimist@^1.2.3:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
+  integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
 minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+
+mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
 
 monaco-editor@^0.34.0:
   version "0.34.0"
@@ -4570,10 +4669,27 @@ nanoid@^3.3.11:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
+napi-build-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-2.0.0.tgz#13c22c0187fcfccce1461844136372a47ddc027e"
+  integrity sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==
+
 ngl@2.0.0-dev.37:
   version "2.0.0-dev.37"
   resolved "https://registry.yarnpkg.com/ngl/-/ngl-2.0.0-dev.37.tgz#6c7052d2b2f9f7db0ee1c13eb0f8711ab3bb9de8"
   integrity sha512-quGzzIoi0RK1s2Y+fvC3WiVj68ObNubKl0NIjrPM1GnHOcVqJnYcvh8PSMaN3CMhrrOkT7kjVWHxgl5UxHLS6Q==
+
+node-abi@^3.3.0:
+  version "3.75.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.75.0.tgz#2f929a91a90a0d02b325c43731314802357ed764"
+  integrity sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==
+  dependencies:
+    semver "^7.3.5"
+
+node-addon-api@^7.0.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
+  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
 
 node-environment-flags@^1.0.5:
   version "1.0.6"
@@ -4655,7 +4771,7 @@ object.getownpropertydescriptors@^2.0.3:
     define-properties "^1.1.3"
     es-abstract "^1.18.0-next.2"
 
-once@^1.3.0:
+once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
@@ -4826,6 +4942,24 @@ postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+prebuild-install@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
+  integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
+  dependencies:
+    detect-libc "^2.0.0"
+    expand-template "^2.0.3"
+    github-from-package "0.0.0"
+    minimist "^1.2.3"
+    mkdirp-classic "^0.5.3"
+    napi-build-utils "^2.0.0"
+    node-abi "^3.3.0"
+    pump "^3.0.0"
+    rc "^1.2.7"
+    simple-get "^4.0.0"
+    tar-fs "^2.0.0"
+    tunnel-agent "^0.6.0"
+
 pretty-format@^27.0.2:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
@@ -4860,6 +4994,14 @@ prop-types@15.8.1, prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.8, 
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+pump@^3.0.0:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.3.tgz#151d979f1a29668dc0025ec589a455b53282268d"
+  integrity sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==
+  dependencies:
+    end-of-stream "^1.1.0"
+    once "^1.3.1"
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -4902,6 +5044,16 @@ raw-loader@^4.0.2:
   dependencies:
     loader-utils "^2.0.0"
     schema-utils "^3.0.0"
+
+rc@^1.2.7:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
+  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+  dependencies:
+    deep-extend "^0.6.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
 
 react-async@^10.0.1:
   version "10.0.1"
@@ -5182,6 +5334,15 @@ reactjs-popup@^2.0.5:
   resolved "https://registry.yarnpkg.com/reactjs-popup/-/reactjs-popup-2.0.5.tgz#588a74966bb126699429d739948e3448d7771eac"
   integrity sha512-b5hv9a6aGsHEHXFAgPO5s1Jw1eSkopueyUVxQewGdLgqk2eW0IVXZrPRpHR629YcgIpC2oxtX8OOZ8a7bQJbxA==
 
+readable-stream@^3.1.1, readable-stream@^3.4.0:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
+  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
@@ -5439,6 +5600,11 @@ rxjs@^7.4.0:
   dependencies:
     tslib "^2.1.0"
 
+safe-buffer@^5.0.1, safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -5643,6 +5809,11 @@ semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
+semver@^7.3.5:
+  version "7.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
+  integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
 set-immediate-shim@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
@@ -5677,6 +5848,20 @@ siginfo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
+simple-concat@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.1.tgz#f46976082ba35c2263f1c8ab5edfe26c41c9552f"
+  integrity sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==
+
+simple-get@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-4.0.1.tgz#4a39db549287c979d352112fa03fd99fd6bc3543"
+  integrity sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==
+  dependencies:
+    decompress-response "^6.0.0"
+    once "^1.3.1"
+    simple-concat "^1.0.0"
 
 slash@^2.0.0:
   version "2.0.0"
@@ -5794,6 +5979,13 @@ string.prototype.trimstart@^1.0.4:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -5807,6 +5999,11 @@ strip-indent@^3.0.0:
   integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
   dependencies:
     min-indent "^1.0.0"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
 strip-literal@^3.0.0:
   version "3.0.0"
@@ -5879,6 +6076,27 @@ sync-message-port@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/sync-message-port/-/sync-message-port-1.1.3.tgz#6055c565ee8c81d2f9ee5aae7db757e6d9088c0c"
   integrity sha512-GTt8rSKje5FilG+wEdfCkOcLL7LWqpMlr2c3LRuKt/YXxcJ52aGSbGBAdI4L3aaqfrBt6y711El53ItyH1NWzg==
+
+tar-fs@^2.0.0:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.1.3.tgz#fb3b8843a26b6f13a08e606f7922875eb1fbbf92"
+  integrity sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.1.4"
+
+tar-stream@^2.1.4:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.2.0.tgz#acad84c284136b060dc3faa64474aa9aebd77287"
+  integrity sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==
+  dependencies:
+    bl "^4.0.3"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 three@^0.125.0:
   version "0.125.2"
@@ -6002,6 +6220,13 @@ tslib@^2.3.0, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
+
+tunnel-agent@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
+  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 typeface-source-sans-pro@^1.1.13:
   version "1.1.13"
@@ -6163,7 +6388,7 @@ use-sync-external-store@^1.0.0:
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz#3343c3fe7f7e404db70f8c687adf5c1652d34e82"
   integrity sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
## Summary
- replace default React imports with hook-based imports
- add docstrings and stronger typings across components
- expose window __NODE_ENV in global types

## Testing
- `yarn build` *(fails: Binding element 'canvasWidthPixel' implicitly has an 'any' type)*
- `yarn test -- --no-file-parallelism` *(fails: module 'canvas' not found and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689760984ac083248b3b4a1c4f780908