### PR TITLE
fix: resolve initial ngs2codfreq build errors

### DIFF
--- a/src/components/ngs2codfreq/fastq-pairs.ts
+++ b/src/components/ngs2codfreq/fastq-pairs.ts
@@ -79,10 +79,22 @@ function* pairingFiles<T>(filenames: T[]): Generator<[T, T], void, unknown> {
 }
 
 
+/**
+ * Infer the common prefix name for a FASTQ pair using the detected pattern.
+ *
+ * When only a single file is present, the file name (without extension) is
+ * returned directly. The function gracefully handles `null` entries within the
+ * pair.
+ *
+ * @param pair - FASTQ files in the pair.
+ * @param pattern - Pattern information describing how the pair was matched.
+ * @returns Suggested name for the pair.
+ */
 function suggestPairName({
-  pair: [{name: fileName}],
+  pair: [file],
   pattern: { delimiter, diffOffset, reverse }
 }: FastqPair): string {
+  const fileName = file?.name ?? '';
   let pairName = fileName.split(/\.fastq(?:\.gz)?/i)[0];
   if (reverse === -1) {
     // single strand
@@ -100,6 +112,13 @@ function suggestPairName({
 }
 
 
+/**
+ * Remove a file from the pair at a given index.
+ *
+ * @param allPairs - Mutable list of all FASTQ pairs.
+ * @param index - Index of the pair to update.
+ * @param fileName - Name of the file to remove.
+ */
 function removeFileUsingRef(
   allPairs: FastqPair[],
   index: number,
@@ -110,9 +129,9 @@ function removeFileUsingRef(
     allPairs.splice(index, 1);
   }
   else {
-    const newPairProps = {
+    const newPairProps: FastqPair = {
       pair: [
-        ...pairProps.pair.filter(f => f.name !== fileName),
+        ...pairProps.pair.filter(f => f && f.name !== fileName),
         null
       ],
       pattern: {
@@ -121,7 +140,8 @@ function removeFileUsingRef(
         posPairedMarker: -1,
         reverse: -1
       },
-      n: 1
+      n: 1,
+      name: ''
     };
     newPairProps.name = suggestPairName(newPairProps);
     allPairs[index] = newPairProps;
@@ -149,13 +169,16 @@ export function moveFile(
   if (targetPair.n === 2) {
     throw new Error('Target group is already paired.');
   }
+  const srcFile = srcPair.pair.find(f => f && f.name === srcFileName) ?? null;
   targetPair.pair = orderBy([
     targetPair.pair[0],
-    srcPair.pair.find(f => f.name === srcFileName)
-  ], ['name']);
-  for (const pattern of findPatterns(...targetPair.pair)) {
-    targetPair.pattern = pattern;
-    break;
+    srcFile
+  ], ['name']) as [File | null, File | null];
+  if (targetPair.pair[0] && targetPair.pair[1]) {
+    for (const pattern of findPatterns(targetPair.pair[0], targetPair.pair[1])) {
+      targetPair.pattern = pattern;
+      break;
+    }
   }
   targetPair.n = 2;
   targetPair.name = suggestPairName(targetPair);

--- a/src/components/ngs2codfreq/index.tsx
+++ b/src/components/ngs2codfreq/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import React from 'react';
 
 import fastq2codfreq, {restoreTask} from '../../utils/fastq2codfreq';
 
@@ -72,7 +71,7 @@ export default function NGS2CodFreq({
 }: NGS2CodFreqProps) {
 
   const [, forceUpdate] = React.useReducer(n => n + 1, 0);
-  const {current: progressLookup} = React.useRef({});
+  const {current: progressLookup} = React.useRef<Record<string, any>>({});
   const [options, setOptions, isOptionsDefault] = useOptions();
 
   React.useEffect(
@@ -105,7 +104,11 @@ export default function NGS2CodFreq({
     async (fastqPairs: FastqPair[]) => {
       if (fastqPairs.length > 0) {
         const {fastpConfig, cutadaptConfig, ivarConfig, primerType} = options;
-        const requestOptions = {fastpConfig};
+        const requestOptions: {
+          fastpConfig: typeof fastpConfig;
+          cutadaptConfig?: typeof cutadaptConfig;
+          ivarConfig?: typeof ivarConfig;
+        } = {fastpConfig};
         if (primerType === 'fasta') {
           requestOptions.cutadaptConfig = cutadaptConfig;
         }

--- a/src/components/ngs2codfreq/options-form/adapter-input.tsx
+++ b/src/components/ngs2codfreq/options-form/adapter-input.tsx
@@ -25,22 +25,24 @@ export default function AdapterInput({
   children
 }: AdapterInputProps) {
   const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
-  const handleChange = React.useCallback(
-    event => {
-      const newValue = event.currentTarget.value;
-      onChange(name, newValue === '' ? autoValue : newValue);
-    },
-    [name, onChange, autoValue]
-  );
+    /** Handle text input changes for adapter sequence. */
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        const newValue = event.currentTarget.value;
+        onChange(name, newValue === '' ? autoValue : newValue);
+      },
+      [name, onChange, autoValue]
+    );
 
-  const handleReset = React.useCallback(
-    event => (
-      event.currentTarget.checked ?
-        onChange(name, autoValue) :
-        textAreaRef.current?.focus()
-    ),
-    [name, onChange, autoValue]
-  );
+    /** Toggle between auto-detect and manual adapter input. */
+    const handleReset = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => (
+        event.currentTarget.checked ?
+          onChange(name, autoValue) :
+          textAreaRef.current?.focus()
+      ),
+      [name, onChange, autoValue]
+    );
 
   return (
     <div className={style['fieldrow']}>

--- a/src/components/ngs2codfreq/options-form/adapter-trimming-switch.tsx
+++ b/src/components/ngs2codfreq/options-form/adapter-trimming-switch.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import React from 'react';
 import RadioInput from '../../radio-input';
 
 import style from './style.module.scss';
@@ -15,13 +14,14 @@ export default function AdapterTrimmingSwitch({
   disableAdapterTrimming,
   onChange
 }: AdapterTrimmingSwitchProps) {
-  const handleChange = React.useCallback(
-    event => onChange(
-      'fastpConfig.disabledAdapterTrimming',
-      event.currentTarget.value === 'no'
-    ),
-    [onChange]
-  );
+    /** Handle adapter trimming toggle. */
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => onChange(
+        'fastpConfig.disabledAdapterTrimming',
+        event.currentTarget.value === 'no'
+      ),
+      [onChange]
+    );
 
   return (
     <div className={style['fieldrow']}>

--- a/src/components/ngs2codfreq/options-form/flag-switch.tsx
+++ b/src/components/ngs2codfreq/options-form/flag-switch.tsx
@@ -23,13 +23,14 @@ export default function DisableFlagSwitch<T>({
   textChoices,
   children
 }: DisableFlagSwitchProps<T>) {
-  const handleChange = React.useCallback(
-    event => onChange(
-      name,
-      valueChoices[Number.parseInt(event.currentTarget.value)]
-    ),
-    [name, valueChoices, onChange]
-  );
+    /** Handle radio selection changes. */
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => onChange(
+        name,
+        valueChoices[Number.parseInt(event.currentTarget.value)]
+      ),
+      [name, valueChoices, onChange]
+    );
 
   return (
     <div className={style['fieldrow']}>

--- a/src/components/ngs2codfreq/options-form/index.tsx
+++ b/src/components/ngs2codfreq/options-form/index.tsx
@@ -98,10 +98,11 @@ export default function NGSOptionsForm({
     'ngs2codfreq-primer-bed-input-desc'
   ], config?.messages);
 
-  const handleSaveInBrowserChange = React.useCallback(
-    event => onChange('saveInBrowser', event.currentTarget.checked),
-    [onChange]
-  );
+    /** Persist configuration changes in browser storage. */
+    const handleSaveInBrowserChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => onChange('saveInBrowser', event.currentTarget.checked),
+      [onChange]
+    );
 
   const handleDownload = React.useCallback(
     () => {
@@ -120,16 +121,19 @@ export default function NGSOptionsForm({
     [fastpConfig, cutadaptConfig, ivarConfig, primerType]
   );
 
-  const handleUpload = React.useCallback(
-    async ([file]) => {
-      const rawJSON = await readFile(file);
-      const payload = JSON.parse(rawJSON);
-      if (isMounted()) {
-        onChange('.', payload);
-      }
-    },
-    [isMounted, onChange]
-  );
+    /** Load a previously saved configuration file. */
+    const handleUpload = React.useCallback(
+      ([file]: File[]) => {
+        void (async () => {
+          const rawJSON = await readFile(file);
+          const payload = JSON.parse(rawJSON);
+          if (isMounted()) {
+            onChange('.', payload);
+          }
+        })();
+      },
+      [isMounted, onChange]
+    );
 
   const handleReset = React.useCallback(
     () => {

--- a/src/components/ngs2codfreq/options-form/number-range-input.tsx
+++ b/src/components/ngs2codfreq/options-form/number-range-input.tsx
@@ -30,26 +30,31 @@ export default function NumberRangeInput({
   disabled,
   children
 }: NumberRangeInputProps) {
-  const handleSelectAll = React.useCallback(
-    event => event.currentTarget.select(),
-    []
-  );
+    /** Select all text in the number input when clicked. */
+    const handleSelectAll = React.useCallback(
+      (event: React.MouseEvent<HTMLInputElement>) => event.currentTarget.select(),
+      []
+    );
 
-  const handleChange = React.useCallback(
-    event => onChange(
-      name,
-      Number.parseFloat(event.currentTarget.value)
-    ),
-    [name, onChange]
-  );
+    /** Propagate value changes from either the range or number input. */
+    const handleChange = React.useCallback(
+      (event: React.ChangeEvent<HTMLInputElement>) => onChange(
+        name,
+        Number.parseFloat(event.currentTarget.value)
+      ),
+      [name, onChange]
+    );
 
-  const handleReset = React.useCallback(
-    event => {
-      event.preventDefault();
-      onChange(name, defaultValue);
-    },
-    [defaultValue, name, onChange]
-  );
+    /** Reset the input back to its default value. */
+    const handleReset = React.useCallback(
+      (event: React.MouseEvent<HTMLAnchorElement>) => {
+        event.preventDefault();
+        if (defaultValue !== undefined) {
+          onChange(name, defaultValue);
+        }
+      },
+      [defaultValue, name, onChange]
+    );
 
   return (
     <div className={style['fieldrow']}>

--- a/src/components/ngs2codfreq/options-form/primer-location-input/index.tsx
+++ b/src/components/ngs2codfreq/options-form/primer-location-input/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import ConfigContext from '../../../../utils/config-context';
-import {useCMS} from '../../../../utils/cms';
+import {useCMS, type CMSConfig} from '../../../../utils/cms';
 
 import Button from '../../../button';
 import FileInput from '../../../file-input';
@@ -16,18 +16,25 @@ import useValidation from './use-validation';
 import style from '../style.module.scss';
 
 
-function guess_strand(strand, name) {
-  if (strand === '+' || strand === '-') {
-    return strand;
-  }
-  else if (/forward|left|fwd|5-?end/i.test(name)) {
+  /**
+   * Infer the strand symbol from free-text description.
+   *
+   * @param strand - Raw strand value.
+   * @param name - Primer name used as fallback.
+   * @returns Standardized '+' or '-' strand designation.
+   */
+  function guess_strand(strand: string | undefined, name: string): '+' | '-' {
+    if (strand === '+' || strand === '-') {
+      return strand;
+    }
+    else if (/forward|left|fwd|5-?end/i.test(name)) {
+      return '+';
+    }
+    else if (/backward|reverse|right|bwd|rev|rvs|3-?end/i.test(name)) {
+      return '-';
+    }
     return '+';
   }
-  else if (/backward|reverse|right|bwd|rev|rvs|3-?end/i.test(name)) {
-    return '-';
-  }
-  return '+';
-}
 
 
 export interface PrimerLocationInputProps {
@@ -50,10 +57,11 @@ export default function PrimerLocationInput({
   );
   const [pendingItems, setPendingItems] = React.useState<PrimerBed[]>([]);
 
+  const cmsConfig = (config ?? {cmsStages: {}}) as CMSConfig;
   const [
     refSequenceText,
     isRefSeqPending
-  ] = useCMS(config.refSequencePath, config);
+  ] = useCMS(config?.refSequencePath ?? '', cmsConfig);
 
   const refSequence = React.useMemo(
     () => !isRefSeqPending && refSequenceText ?


### PR DESCRIPTION
## Summary
- refine FASTQ pair utilities with null-safe handling
- type NGS options forms and trim adapters reliably
- add docstrings and explicit event typings for options UI

## Testing
- `yarn build` *(fails: Cannot find name 'importScripts', Cannot find namespace 'JSX', etc.)*
- `yarn test -- --no-file-parallelism` *(fails: Package subpath './src/forEach' is not defined by "exports" in ramda package)*

------
https://chatgpt.com/codex/tasks/task_e_6897d574d41883249b27af289547b829