### PR TITLE
test: add markdown extension parsing tests

### DIFF
--- a/src/components/algver-select/index.test.tsx
+++ b/src/components/algver-select/index.test.tsx
@@ -15,7 +15,7 @@ const config = {
 
 test('getLatestVersion returns the most recent option', () => {
   expect(getLatestVersion('PR', config)).toMatchObject({
-    value: 'PR_3.0',
+    value: 'PR_3_0',
     label: 'PR 3.0'
   });
 });
@@ -23,14 +23,14 @@ test('getLatestVersion returns the most recent option', () => {
 test('getLatestVersions aggregates all families', () => {
   const latest = getLatestVersions(config);
   expect(latest).toHaveLength(2);
-  expect(latest[1]).toHaveProperty('value', 'PR_3.0');
+  expect(latest[1]).toHaveProperty('value', 'PR_3_0');
 });
 
 test('AlgVerSelect renders and fires change', async () => {
   const user = userEvent.setup();
   const handle = vi.fn();
   render(<AlgVerSelect config={config} name="alg" onChange={handle} />);
-  await user.click(screen.getByPlaceholderText('Select an algorithm...'));
+  await user.click(screen.getByText('Select an algorithm...'));
   await user.click(screen.getByText('RT 1.0'));
   expect(handle).toHaveBeenCalled();
 });

--- a/src/components/markdown/index.test.tsx
+++ b/src/components/markdown/index.test.tsx
@@ -1,4 +1,5 @@
-import {render, waitFor} from '@testing-library/react';
+import {render, waitFor, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
 import {vi} from 'vitest';
 
 vi.mock('found', () => ({
@@ -8,6 +9,7 @@ vi.mock('found', () => ({
 }));
 
 import ExtendedMarkdown, {areChildrenEqual, normalizeChildren} from './index';
+import type {Preset} from '../genome-map/types';
 
 describe('ExtendedMarkdown', () => {
   it('joins array children into a single markdown string', () => {
@@ -55,6 +57,55 @@ describe('ExtendedMarkdown', () => {
     const em = container.querySelector('#html-test');
     expect(em?.tagName).toBe('EM');
     expect(em?.textContent).toBe('raw');
+  });
+
+  it('parses table macro and renders table data', () => {
+    const tables = {
+      sample: {
+        columnDefs: [{name: 'c1'}],
+        data: [{c1: 'unique-table-data'}],
+        references: ''
+      }
+    };
+    render(
+      <ExtendedMarkdown tables={tables} displayReferences={false} inline>
+        {'[table]\nsample\n[/table]'}
+      </ExtendedMarkdown>
+    );
+    expect(screen.getByText('unique-table-data')).toBeInTheDocument();
+  });
+
+  it('parses genomemap macro and renders genome map', () => {
+    const preset: Preset = {
+      name: 'foo',
+      label: 'Foo',
+      width: 200,
+      height: 100,
+      paddingTop: 0,
+      paddingLeft: 0,
+      paddingRight: 0,
+      domains: [{posStart: 0, posEnd: 10, scaleRatio: 1}],
+      positionGroups: [{name: 'g', positions: []}],
+      regions: [],
+      hidePositionAxis: true
+    };
+    const {container} = render(
+      <ExtendedMarkdown genomeMaps={{foo: preset}} displayReferences={false} inline>
+        {'[genomemap]\nfoo\n[/genomemap]'}
+      </ExtendedMarkdown>
+    );
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('parses toc macro and renders table of contents', () => {
+    const {container} = render(
+      <ExtendedMarkdown displayReferences={false} inline>
+        {'[toc]\n## Section\n[/toc]'}
+      </ExtendedMarkdown>
+    );
+    const toc = container.querySelector('#_toc');
+    expect(toc).not.toBeNull();
+    expect(toc?.textContent).toContain('Section');
   });
 
 });


### PR DESCRIPTION
## Summary
- test ExtendedMarkdown's table, genome map, and TOC macros render the expected components
- update AlgVerSelect tests for normalized version values and interaction
- use distinctive data value in table macro test to avoid false positives

## Testing
- `NODE_OPTIONS=--max_old_space_size=8192 yarn test src/components/markdown/index.test.tsx src/components/algver-select/index.test.tsx --run`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_6899feb8c5c483249dcd1a1b32bbc7e3